### PR TITLE
Add native support for new (Slackware 15.0) local packages directory

### DIFF
--- a/slackroll
+++ b/slackroll
@@ -54,8 +54,7 @@ slackroll_default_temp_dir = os.path.join(slackroll_base_dir, 'tmp')
 slackroll_pkgs_dir_glob = os.path.join(slackroll_base_dir, 'packages', '*')
 slackroll_pkgs_dir = os.path.dirname(slackroll_pkgs_dir_glob)
 slackroll_help_file_template = os.path.join(os.path.sep, 'usr', 'doc', 'slackroll-v%s' % slackroll_version, 'helpfiles', '%s.txt')
-slackroll_local_pkgs_glob = os.path.join(os.path.sep, 'var', 'log', 'packages', '*')
-slackroll_local_pkgs_dir = os.path.dirname(slackroll_local_pkgs_glob)
+slackroll_local_pkgs_dir_names = [os.path.join(os.path.sep, 'var', 'lib', 'pkgtools', 'packages'), os.path.join(os.path.sep, 'var', 'log', 'packages')]
 slackroll_local_pkg_filelist_marker = 'FILE LIST:\n'
 slackroll_filelist_pkg_re = re.compile(
         # Output line in ls form
@@ -130,6 +129,15 @@ slackroll_manifest_basename = 'MANIFEST.bz2'
 slackroll_manifest_filename = os.path.join(slackroll_base_dir, 'manifest.db')
 slackroll_manifest_list_filename = os.path.join(slackroll_base_dir, 'manifestlist.db')
 slackroll_batch_mode = False
+
+def yield_slackroll_local_pkgs_dir():
+    for opt in slackroll_local_pkgs_dir_names:
+        while os.path.isdir(opt):
+            yield opt
+    sys.exit('ERROR: unable to find local packages directgory')
+
+slackroll_local_pkgs_glob = os.path.join(yield_slackroll_local_pkgs_dir().next(), '*')
+slackroll_local_pkgs_dir = os.path.dirname(slackroll_local_pkgs_glob)
 
 def standarize_locales():
     for varname in slackroll_locale_envvars:
@@ -514,7 +522,7 @@ def extract_file_list(filename): # Extracts the file list from a local info file
     except (OSError, IOError), err:
         sys.exit('ERROR: %s' % err)
 
-def get_pkg_filelists(): # Return a dictionary of filename->filelist from /var/log/packages
+def get_pkg_filelists(): # Return a dictionary of filename->filelist from slackroll_local_pkgs_dir
     if newer_than(slackroll_local_pkgs_dir, slackroll_pkg_files_filename):
         try:
             filenames = glob.glob(slackroll_local_pkgs_glob)
@@ -539,7 +547,7 @@ def get_normalized_known_files(): # Return a set of known files for orphan-searc
         try_dump(known_files, slackroll_known_files)
     return try_load(slackroll_known_files)
 
-def get_local_pkgs(): # Return a list of packages from /var/log/packages
+def get_local_pkgs(): # Return a list of packages from slackroll_local_pkgs_dir
     local_pkgs = glob.glob(slackroll_local_pkgs_glob)
     if len(local_pkgs) == 0:
         sys.exit('ERROR: could not read list of local packages')


### PR DESCRIPTION
This mimics the fallback behaviour for choosing a GPG version, by first
checking if the new packages location exists, otherwise checking for the
old packages directory.