### PR TITLE
Bump version number.

### DIFF
--- a/slackroll
+++ b/slackroll
@@ -36,7 +36,7 @@ import termios
 import urllib
 import urlparse
 
-slackroll_version = 48
+slackroll_version = 49
 
 slackroll_exit_failure = 1
 slackroll_exit_success = 0


### PR DESCRIPTION
Seems we are close to a new Slackware release. We've seen Slackware 15 RC2 now. Could we merge this and get a new tag?