### PR TITLE
Quality of life improvements:

### DIFF
--- a/helpfiles/all.txt
+++ b/helpfiles/all.txt
@@ -29,6 +29,7 @@ Common operations:
 
 Kernel upgrades:
 
+  list-kernels      Show all installed and available kernel packages
   kernel-upgrade	Install updated kernel packages with installpkg
   kernel-clean		Remove obsolete kernel packages
 
@@ -93,6 +94,9 @@ Other package listing operations:
   list-outdated-frozen	List frozen packages that would be outdated otherwise
   list-versions PKG...	List all known versions of the given packages
 
+  foreign-upgradable    List foreign packages that are now available in repo
+  frozen-upgradable     List frozen packages that could be upgraded if unfrozen
+
 
 Other change log operations:
 
@@ -114,7 +118,14 @@ Displaying package URLs (e.g. for feeding them to a downloader program):
 Package information (i.e. related to .txt, slack-desc or installation files):
 
   info PKG...		Show info about packages or specific package versions
+  info-foreign   Show info about all foreign packages
+  info-frozen   Show info about all frozen packages
+  info-installed    Show info about all installed packages
   info-new		Show info about all new packages
+  info-not-installed  Show info about all packages in repo but not installed
+  info-transient    Show info about all packages in a transient state
+  info-outdated  Show info about all packages with upgrades available in repo
+  info-unavailable  Show info about all installed packages not in repo or marked as foreign
   info-path REGEXP...	Show info about all packages with matching path
   local-info PKG...	Show full package information from /var/log/packages
 

--- a/helpfiles/all.txt
+++ b/helpfiles/all.txt
@@ -156,9 +156,10 @@ Searching for packages and files:
 
 Other maintenance operations (usually not needed):
 
-  erase-cache		Remove every file from package cache
+  erase-cache	Remove every file from package cache
+  erase-info	Remove package info (.txt) files from cache
   erase-tmp		Remove every file from the temporary directory
-  erase-all		Remove every file from both locations above
+  erase-all		Remove every file from all locations above
   touch			Force update on persistent database
 
 

--- a/helpfiles/list-upgrades.txt
+++ b/helpfiles/list-upgrades.txt
@@ -1,9 +1,15 @@
 
 list-upgrades
 
-This operation expects no arguments. It will print a detailed list of packages
-in the "outdated" state. The list includes the currently installed version of
-every outdated packages, as well as every known remote version of them.
+Prints a detailed list of all packages in the "outdated" state. The list
+includes the currently installed version of every outdated packages, as well
+as every known remote version of them.
+
+This operation requires no arguments, but just like the "upgrade" command,
+you can optionally append '--auto-select' to only consider installation
+candidates whose build suffix matches an already-installed version.  This is
+useful if your repos often provide alternate versions of the same package.
+See the "slackroll help upgrade" page for further details on this option.
 
 Normally, this operation is not needed, as "list-transient" provides the list
 of every package in a transient state, including "outdated" packages, and

--- a/helpfiles/upgrade-key-packages.txt
+++ b/helpfiles/upgrade-key-packages.txt
@@ -1,12 +1,12 @@
 
 upgrade-key-packages
 
-It's essentially an operation similar to "upgrade", but it only affects the
-key system packages (aaa_glibc-solibs, glibc-solibs, sed and pkgtools), which
-usually should be upgraded before any other outdated or new package, unless
-there's a specific reason (probably mentioned in the change log) to install or
-upgrade other packages first. It's normally only run after "list-transient"
-when you detect they are outdated.
+Essentially similar to "upgrade", but it only affects the key system packages
+(aaa_glibc-solibs, glibc-solibs, sed and pkgtools), which usually should be
+upgraded before any other outdated or new package, unless there's a specific
+reason (probably mentioned in the change log) to install or upgrade other
+packages first. It's normally only run after "list-transient" when you detect
+they are outdated.
 
 Two important notes: list-transient will notice there are outdated system
 packages and emit a big and noticeable warning at the end of the package list
@@ -20,10 +20,10 @@ list-transient always lists packages in the common preferred order, and you
 will notice it always puts key system packages first when they are outdated.
 
 This operation requires no arguments, but just like the "upgrade" command,
-you can optionally append '--auto-select' to have slackroll automatically
-ignore any installation candidates that don't have the same build suffix
-as the already-installed version.  See the "slackroll help upgrade" page for
-further details on this option.
+you can optionally append '--auto-select' to automatically ignore any
+installation candidates that don't have the same build suffix as an
+already-installed version.  See the "slackroll help upgrade" page for further
+details on this option.
 
 Also see: list-transient.
 

--- a/helpfiles/upgrade-key-packages.txt
+++ b/helpfiles/upgrade-key-packages.txt
@@ -1,12 +1,12 @@
 
 upgrade-key-packages
 
-This operation expects no arguments. It's essentially an operation similar to
-"upgrade", but it only affects the key system packages (aaa_glibc-solibs,
-glibc-solibs, sed and pkgtools), which usually should be upgraded before any
-other outdated or new package, unless there's a specific reason (probably
-mentioned in the change log) to install or upgrade other packages first. It's
-normally only run after "list-transient" when you detect they are outdated.
+It's essentially an operation similar to "upgrade", but it only affects the
+key system packages (aaa_glibc-solibs, glibc-solibs, sed and pkgtools), which
+usually should be upgraded before any other outdated or new package, unless
+there's a specific reason (probably mentioned in the change log) to install or
+upgrade other packages first. It's normally only run after "list-transient"
+when you detect they are outdated.
 
 Two important notes: list-transient will notice there are outdated system
 packages and emit a big and noticeable warning at the end of the package list
@@ -18,6 +18,12 @@ need to explicitly run "upgrade-key-packages" first.
 
 list-transient always lists packages in the common preferred order, and you
 will notice it always puts key system packages first when they are outdated.
+
+This operation requires no arguments, but just like the "upgrade" command,
+you can optionally append '--auto-select' to have slackroll automatically
+ignore any installation candidates that don't have the same build suffix
+as the already-installed version.  See the "slackroll help upgrade" page for
+further details on this option.
 
 Also see: list-transient.
 

--- a/helpfiles/upgrade.txt
+++ b/helpfiles/upgrade.txt
@@ -1,16 +1,14 @@
 
 upgrade
 
-Upgrade will do a lot things for you, but
-the general purpose is to upgrade outdated packages. It will not install new
-packages and it will not remove unavailable packages. Only outdated packages
-are taken into account.
+Upgrade will do a lot things for you, but the general purpose is to upgrade
+outdated packages. It will not install new packages and it will not remove
+unavailable packages. Only outdated packages are taken into account.
 
 Its main actions are downloading, verifying package signatures and upgrading,
 using upgradepkg, the packages that are outdated. It will do extra things
 sometimes, like letting you review .new files or letting you choose a specific
-package version if several ones are available, but its usage is mostly
-intuitive.
+package version if several are available, but its usage is mostly intuitive.
 
 When it prompts you to choose a specific package version, it will also print
 the version currently installed just above the choice question, as this may
@@ -20,20 +18,21 @@ For a description on how reviewing .new files works, read the help on the
 "dotnew" topic.
 
 This operation requires no arguments, but you can optionally append
-'--auto-select' to have slackroll automatically ignore any installation
-candidates that don't have the same build suffix as the already-installed
-version.  For example, if you have an _SBo version of a package installed,
-this option will prevent 'slackroll upgrade' from automatically replacing
-it with a version from the standard repository.  This can be particularly
-useful if you use a third-party repository which provides alternate versions
-for a large number of standard packages, such as _lngn (KDE Plasma 6).
-Without the '--auto-select' option, slackroll would manually prompt you to
-choose between the standard and third-party versions of every package that
-exists in both repos.  With '--auto-select', slackroll assumes that any
-packages that already have _lngn versions installed should continue to
-follow the _lngn versions, and packages with the standard versions installed
-should continue to use the standard versions, any packages with _alien
-versions installed should continue to follow the _alien repository, etc.
+'--auto-select' to automatically ignore any installation candidates that don't
+have the same build suffix as an already-installed version.  For example, if
+you have only an _SBo version of a particular package installed, this option
+will prevent 'slackroll upgrade' from automatically replacing it with a version
+from a remote repository.  This can be particularly useful if you use a
+third-party repository which provides alternate versions for a large number of
+standard packages, such as _lngn (KDE Plasma 6).  Without '--auto-select',
+slackroll would manually prompt you to choose between the standard and
+third-party versions of every package that exists in both repos.  With
+'--auto-select', slackroll assumes that any packages that only have _lngn
+versions currently installed should continue to follow the _lngn versions, any
+any packages with only _alien versions installed should continue to follow the
+_alien repository, etc.  You normally shouldn't have different versions of a
+package locally installed, but if for some reason you do, '--auto-select' will
+consider upgrades that match /any/ of the already-installed versions.
 
-Also see: list-transient.
+Also see: list-transient, list-upgrades, upgrade-key-packages.
 

--- a/helpfiles/upgrade.txt
+++ b/helpfiles/upgrade.txt
@@ -1,7 +1,7 @@
 
 upgrade
 
-This operation expects no arguments. Upgrade will do a lot things for you, but
+Upgrade will do a lot things for you, but
 the general purpose is to upgrade outdated packages. It will not install new
 packages and it will not remove unavailable packages. Only outdated packages
 are taken into account.
@@ -18,6 +18,22 @@ give you clues about which one you may want to install.
 
 For a description on how reviewing .new files works, read the help on the
 "dotnew" topic.
+
+This operation requires no arguments, but you can optionally append
+'--auto-select' to have slackroll automatically ignore any installation
+candidates that don't have the same build suffix as the already-installed
+version.  For example, if you have an _SBo version of a package installed,
+this option will prevent 'slackroll upgrade' from automatically replacing
+it with a version from the standard repository.  This can be particularly
+useful if you use a third-party repository which provides alternate versions
+for a large number of standard packages, such as _lngn (KDE Plasma 6).
+Without the '--auto-select' option, slackroll would manually prompt you to
+choose between the standard and third-party versions of every package that
+exists in both repos.  With '--auto-select', slackroll assumes that any
+packages that already have _lngn versions installed should continue to
+follow the _lngn versions, and packages with the standard versions installed
+should continue to use the standard versions, any packages with _alien
+versions installed should continue to follow the _alien repository, etc.
 
 Also see: list-transient.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slackroll"
-version = "51"
+version = "53"
 description = "Package or upgrade manager for Slackware Linux"
 authors = ["Ricardo Garcia <commits@rg3.name>", "Andrew Clemons <andrew.clemons@gmail.com>"]
 license = "CC0 Public Domain Dedication"

--- a/slackroll
+++ b/slackroll
@@ -2697,7 +2697,7 @@ if __name__ == "__main__":
             current_list = [(x.name, x.version + '-' + x.build) for x in auto_kernel_pkgs if not superseded_in(x, latest_kernel_pkgs)]
             superseded_list = [(x.name, x.version + '-' + x.build) for x in auto_kernel_pkgs if superseded_in(x, auto_kernel_pkgs)]
             upgradable_list = [(x.name, x.version + '-' + x.build) for x in latest_kernel_pkgs if x.name in auto_kernel_pkg_names and x not in auto_kernel_pkgs]
-            keeper_list = [(x.name, x.version + '-' + x.build) for x in auto_kernel_pkgs if not superseded_in(x, auto_kernel_pkgs) and (x.name, x.version) not in current_list]
+            keeper_list = [(x.name, x.version + '-' + x.build) for x in auto_kernel_pkgs if not superseded_in(x, auto_kernel_pkgs) and (x.name, x.version + '-' + x.build) not in current_list]
             manual_list = [(x.name, x.version + '-' + x.build) for x in manual_kernel_pkgs]
             available_list = [(x.name, x.version + '-' + x.build) for x in new_kernel_pkgs]
 

--- a/slackroll
+++ b/slackroll
@@ -90,8 +90,6 @@ import termios
 import urllib.request, urllib.parse, urllib.error
 import urllib.parse
 from functools import reduce
-from packaging import version
-
 from tempfile import mkdtemp
 from packaging import version
 
@@ -204,7 +202,7 @@ def yield_slackroll_local_pkgs_dir():
         while os.path.isdir(opt):
             yield opt
 
-    sys.exit('ERROR: Unable to find local packages directory')
+    sys.exit('ERROR: unable to find local packages directory')
 
 if __name__ == "__main__":
     slackroll_local_pkgs_glob = os.path.join(next(yield_slackroll_local_pkgs_dir()), '*')
@@ -1479,7 +1477,7 @@ def handle_dotnew_files_installation_interactive(dotnew_files): # Handles .new f
                     run_visual_on(newfile)
 
             elif not new_exists and old_exists: # Old only
-                # BCS: skip the prompt as there's really no reason to bother the user
+                # BCS: skip the prompt; if no new version, there's no reason to bother the user
                 break
             else: # None
                 options = [go_next]
@@ -1989,6 +1987,7 @@ def load_persistent_db(filename):
     # installations will immediately default to the new format. We can then
     # ship the python3 version safely.
     data = shelve.open(filename, 'c', pickle_protocol)
+
     if not PY2:
         return data
 
@@ -2043,8 +2042,10 @@ if __name__ == "__main__":
             'erase-all':                0,
             'foreign':                  -1,
             'foreign-upgradable':       0,
+            'foreign-upgradeable':      0,
             'frozen':                   -1,
             'frozen-upgradable':        0,
+            'frozen-upgradeable':       0,
             'freeze':                   -1,
             'full-changelog':           0,
             'help':                     -2,
@@ -2055,10 +2056,10 @@ if __name__ == "__main__":
             'info-installed':           0,
             'info-new':                 0,
             'info-not-installed':       0,
-            'info-outdated' :           0,
+            'info-outdated':            0,
             'info-path':                -1,
-            'info-transient' :          0,
-            'info-unavailable' :        0,
+            'info-transient':           0,
+            'info-unavailable':         0,
             'install':                  -1,
             'install-foreign':          -1,
             'install-new':              0,
@@ -2104,6 +2105,8 @@ if __name__ == "__main__":
             'remove-repo':              -1,
             'remove-unavailable':       0,
             'replace':                  2,
+            'search-name':              -1,
+            'search-path':              -1,
             'set-mirror':               1,
             'set-primary-mirror':       1,
             'state':                    -1,
@@ -2458,7 +2461,7 @@ if __name__ == "__main__":
 
             opmap = { 'upgrade': 'install', 'download-upgrades': 'download', 'urls-upgrades': 'urls' }
             if operation == 'upgrade':
-                # BCS: don't inadvertently upgrade kernel packages except via the kernel-upgrade command
+                # BCS: don't upgrade kernel packages except via an explicit kernel-upgrade command
                 names = [x for x in names if not x.startswith(slackroll_kernel_pkg_indicator)]
             install_operations_family(opmap[operation], names, local_list, remote_list, persistent_list, use_pasture=False)
             sys.exit()
@@ -2505,23 +2508,23 @@ if __name__ == "__main__":
                 print('\n'.join('WARNING: extraneous file %s' % x for x in extraneous_files))
             sys.exit()
 
-        # BCS: list-upgradable as an alias for list-upgrades to ease the learning curve for those used to apt
-        if operation in ['list-upgrades', 'list-upgradable', 'list-outdated-frozen']:
-            if operation in ['list-upgrades', 'list-upgradable']:
+        # BCS: list-upgradable is an alias for list-upgrades to ease the learning curve for those used to apt
+        if operation in ['list-upgrades', 'list-upgradable', 'list-upgradeable', 'list-outdated-frozen']:
+            if operation in ['list-upgrades', 'list-upgradable', 'list-upgradeable']:
                 names = pkgs_in_state(persistent_list, [slackroll_state_outdated])
             else: # list-outdated-frozen
                 names = pkgs_in_state(persistent_list, [slackroll_state_frozen])
                 names = [x for x in names if not up_to_date(local_list[x], not_pasture(remote_list[x]))]
 
             if len(names) == 0:
-                if operation == 'list-upgrades':
+                if operation in ['list-upgrades', 'list-upgradable', 'list-upgradeable']:
                     print('No outdated packages')
                 else: # list-outdated-frozen
                     print('No frozen packages would be outdated')
                 sys.exit()
 
             interceptor = SlackrollOutputInterceptor()
-            if operation == 'list-upgrades':
+            if operation in ['list-upgrades', 'list-upgradable', 'list-upgradeable']:
                 print('Available upgrades:')
             else: # list-outdated-frozen
                 print('Would be outdated:')
@@ -2538,7 +2541,7 @@ if __name__ == "__main__":
                 print()
             print('End of list')
 
-            if operation in ['list-upgrades', 'list-upgradable']:
+            if operation in ['list-upgrades', 'list-upgradable', 'list-upgradeable']:
                 maybe_print_key_pkg_watchout(persistent_list)
             interceptor.stop()
             sys.exit()
@@ -2561,6 +2564,9 @@ if __name__ == "__main__":
             print('Transient packages:')
             print('\n'.join(format % (state, name, tr_pkg_detail(local_list, remote_list, persistent_list, name)) for (name, state) in pkgs_and_states))
             print('End of list')
+            maybe_print_key_pkg_watchout(persistent_list)
+            interceptor.stop()
+            sys.exit()
 
         if operation == 'list-new':
             # Very similar to list-transient
@@ -2613,8 +2619,8 @@ if __name__ == "__main__":
                 print('No %s packages' % state_str)
             else:
                 install_operations_family('info', names, local_list, remote_list, persistent_list)
-                sys.exit()
-
+            sys.exit()
+            
         if operation in ['list-outdated', 'list-unavailable', 'list-installed', 'list-not-installed', 'list-frozen', 'list-foreign']:
             state_str = operation.replace('list-', '')
             header = '%s packages:' % state_str.capitalize()
@@ -2641,7 +2647,7 @@ if __name__ == "__main__":
             newer_available_pkgs = [x for x in local_pkgs if superseded_in(x, repo_pkgs)]
 
             interceptor = SlackrollOutputInterceptor()
-            print_list_or([x.name for x in newer_available_pkgs], header, empty_message)
+            print_pairs_or([(x.name, x.version + ' installed, ' + ', '.join([y.version for y in repo_pkgs if y.name == x.name]) + ' available') for x in newer_available_pkgs], header, empty_message)
             interceptor.stop()
             sys.exit()
 

--- a/slackroll
+++ b/slackroll
@@ -61,6 +61,7 @@ import termios
 import urllib.request, urllib.parse, urllib.error
 import urllib.parse
 from functools import reduce
+from packaging import version
 
 from tempfile import mkdtemp
 
@@ -166,13 +167,13 @@ def yield_slackroll_local_pkgs_dir():
         while os.path.isdir(opt):
             yield opt
 
-    sys.exit('ERROR: unable to find local packages directgory')
+    sys.exit('ERROR: Unable to find local packages directory')
 
 if __name__ == "__main__":
     slackroll_local_pkgs_glob = os.path.join(next(yield_slackroll_local_pkgs_dir()), '*')
     slackroll_local_pkgs_dir = os.path.dirname(slackroll_local_pkgs_glob)
 
-def standarize_locales():
+def standardize_locales():
     for varname in slackroll_locale_envvars:
         if varname in os.environ:
             del os.environ[varname]
@@ -1148,13 +1149,31 @@ def print_list(the_list, header): # Print every list entry, sorted
         print('    %s' % entry)
     print('End of list')
 
-def print_list_or(the_list, header, message_on_emtpy): # Idem using interceptor and a message if empty list
+def print_list_or(the_list, header, message_on_empty): # Idem using interceptor and a message if empty list
     if len(the_list) == 0:
-        print(message_on_emtpy)
+        print message_on_empty
         return
     interceptor = SlackrollOutputInterceptor()
     print_list(the_list, header)
     interceptor.stop()
+
+# BCS: useful for printing version numbers within some commands, e.g. maintaining kernel packages
+def print_pairs_or(the_list, header, message_on_empty):
+    if len(the_list) == 0:
+        print message_on_empty
+        return
+    interceptor = SlackrollOutputInterceptor()
+    print header
+    the_list.sort()
+    for (a, b) in the_list:
+        print ' %s (%s)' % (a, b)
+    interceptor.stop()
+
+def superseded_in(pkg, the_list):
+    name = pkg.name
+    old_version = version.parse(pkg.version)
+    newer_pkgs = [x for x in the_list if x.name == name and version.parse(x.version) > old_version]
+    return len(newer_pkgs) > 0
 
 def tr_pkg_detail(local_list, remote_list, persistent_list, pkg_name): # Returns a string with package details for a transient package
     if persistent_list[pkg_name] != slackroll_state_new:
@@ -1286,12 +1305,8 @@ def handle_dotnew_files_installation_interactive(dotnew_files): # Handles .new f
                     run_visual_on(newfile)
 
             elif not new_exists and old_exists: # Old only
-                options = [go_next, visual_old]
-                chosen = choose_option(options)
-                if chosen == 0:
-                    break
-                else:
-                    run_visual_on(oldfile)
+                # BCS: skip the prompt as there's really no reason to bother the user
+                break
             else: # None
                 options = [go_next]
                 chosen = choose_option(options)
@@ -1797,7 +1812,6 @@ def load_persistent_db(filename):
     # installations will immediately default to the new format. We can then
     # ship the python3 version safely.
     data = shelve.open(filename, 'c', pickle_protocol)
-
     if not PY2:
         return data
 
@@ -1828,9 +1842,9 @@ if __name__ == "__main__":
         local_list = None
         remote_list = None
         persistent_list = None
-        urllib.request._urlopener = SlackrollURLopener()
+        urllib._urlopener = SlackrollURLopener()
         socket.setdefaulttimeout(slackroll_socket_timeout)
-        standarize_locales()
+        standardize_locales()
 
         op_num_args = {    # Map of operations and their appropriate number of arguments.
             'add-repo':                 -1,
@@ -1851,14 +1865,23 @@ if __name__ == "__main__":
             'erase-tmp':                0,
             'erase-all':                0,
             'foreign':                  -1,
+            'foreign-upgradable':       0,
             'frozen':                   -1,
+            'frozen-upgradable':        0,
             'freeze':                   -1,
             'full-changelog':           0,
             'help':                     -2,
             'import-key':               0,
             'info':                     -1,
+            'info-foreign':             0,
+            'info-frozen':              0,
+            'info-installed':           0,
             'info-new':                 0,
+            'info-not-installed':       0,
+            'info-outdated' :           0,
             'info-path':                -1,
+            'info-transient' :          0,
+            'info-unavailable' :        0,
             'install':                  -1,
             'install-foreign':          -1,
             'install-new':              0,
@@ -1872,6 +1895,7 @@ if __name__ == "__main__":
             'list-foreign':             0,
             'list-frozen':              0,
             'list-installed':           0,
+            'list-kernels':             0,
             'list-local':               0,
             'list-new':                 0,
             'list-not-installed':       0,
@@ -2245,13 +2269,16 @@ if __name__ == "__main__":
                 maybe_confirm_continue()
 
             names = pkgs_in_state(persistent_list, [slackroll_state_outdated])
-            names.sort(key=functools.cmp_to_key(pkg_name_cmp))
+            names.sort(cmp=pkg_name_cmp))
 
             if len(names) == 0:
                 print('No outdated packages')
                 sys.exit()
 
             opmap = { 'upgrade': 'install', 'download-upgrades': 'download', 'urls-upgrades': 'urls' }
+            if operation == 'upgrade':
+                # BCS: don't inadvertently upgrade kernel packages except via the kernel-upgrade command
+                names = [x for x in names if not x.startswith(slackroll_kernel_pkg_indicator)]
             install_operations_family(opmap[operation], names, local_list, remote_list, persistent_list, use_pasture=False)
             sys.exit()
 
@@ -2297,8 +2324,9 @@ if __name__ == "__main__":
                 print('\n'.join('WARNING: extraneous file %s' % x for x in extraneous_files))
             sys.exit()
 
-        if operation in ['list-upgrades', 'list-outdated-frozen']:
-            if operation == 'list-upgrades':
+        # BCS: list-upgradable as an alias for list-upgrades to ease the learning curve for those used to apt
+        if operation in ['list-upgrades', 'list-upgradable', 'list-outdated-frozen']:
+            if operation in ['list-upgrades', 'list-upgradable']:
                 names = pkgs_in_state(persistent_list, [slackroll_state_outdated])
             else: # list-outdated-frozen
                 names = pkgs_in_state(persistent_list, [slackroll_state_frozen])
@@ -2329,7 +2357,7 @@ if __name__ == "__main__":
                 print()
             print('End of list')
 
-            if operation == 'list-upgrades':
+            if operation in ['list-upgrades', 'list-upgradable']:
                 maybe_print_key_pkg_watchout(persistent_list)
             interceptor.stop()
             sys.exit()
@@ -2352,9 +2380,6 @@ if __name__ == "__main__":
             print('Transient packages:')
             print('\n'.join(format % (state, name, tr_pkg_detail(local_list, remote_list, persistent_list, name)) for (name, state) in pkgs_and_states))
             print('End of list')
-            maybe_print_key_pkg_watchout(persistent_list)
-            interceptor.stop()
-            sys.exit()
 
         if operation == 'list-new':
             # Very similar to list-transient
@@ -2394,6 +2419,21 @@ if __name__ == "__main__":
             interceptor.stop()
             sys.exit()
 
+        # BCS: easier access to info files for interesting package categories
+        if operation in ['info-outdated', 'info-unavailable', 'info-installed', 'info-not-installed', 'info-frozen', 'info-foreign', 'info-transient']:
+            state_str = operation.replace('info-', '')
+            if state_str == 'transient':
+                states = slackroll_transient_states
+            else:
+                states = [slackroll_state_strings.index(state_str)]
+            names = pkgs_in_state(persistent_list, states)
+            names.sort(cmp=pkg_name_cmp)
+            if len(names) == 0:
+                print 'No %s packages' % state_str
+            else:
+                install_operations_family('info', names, local_list, remote_list, persistent_list)
+                sys.exit()
+
         if operation in ['list-outdated', 'list-unavailable', 'list-installed', 'list-not-installed', 'list-frozen', 'list-foreign']:
             state_str = operation.replace('list-', '')
             header = '%s packages:' % state_str.capitalize()
@@ -2404,6 +2444,23 @@ if __name__ == "__main__":
             print_in_states_or([state], persistent_list, header, empty_message, False)
             if state in slackroll_transient_states:
                 maybe_print_key_pkg_watchout(persistent_list)
+            interceptor.stop()
+            sys.exit()
+
+        # BCS: see packages that might have been previously marked as foreign, but are now available in the repo,
+        #      or that were manually frozen, but could be upgraded if unfrozen
+        if operation in ['foreign-upgradable', 'foreign-upgradeable', 'frozen-upgradable', 'frozen-upgradeable']:
+            state_str = operation.replace('-upgradable', '').replace('-upgradeable', '')
+            state = slackroll_state_strings.index(state_str)
+            header = 'Upgradable %s packages:' % state_str
+            empty_message = 'No upgradable %s packages found' % state_str
+
+            local_pkgs = concat([local_list[x] for x in local_list if persistent_list[x] == state])
+            repo_pkgs = concat([remote_list[x] for x in remote_list if persistent_list[x] == state])
+            newer_available_pkgs = [x for x in local_pkgs if superseded_in(x, repo_pkgs)]
+
+            interceptor = SlackrollOutputInterceptor()
+            print_list_or([x.name for x in newer_available_pkgs], header, empty_message)
             interceptor.stop()
             sys.exit()
 
@@ -2630,18 +2687,46 @@ if __name__ == "__main__":
             remove_pkgs(to_be_removed)
             sys.exit()
 
+        if operation == 'list-kernels':
+            auto_kernel_pkgs = concat([local_list[x] for x in local_list if x.startswith(slackroll_kernel_pkg_indicator) and (persistent_list[x] == slackroll_state_installed or persistent_list[x] == slackroll_state_outdated)])
+            manual_kernel_pkgs = concat([local_list[x] for x in local_list if x.startswith(slackroll_kernel_pkg_indicator) and (persistent_list[x] == slackroll_state_frozen or persistent_list[x] == slackroll_state_foreign)])
+            latest_kernel_pkgs = concat([remote_list[x] for x in remote_list if x.startswith(slackroll_kernel_pkg_indicator) and not (persistent_list[x] == slackroll_state_frozen or persistent_list[x] == slackroll_state_foreign)])
+            new_kernel_pkgs = concat([remote_list[x] for x in remote_list if x.startswith(slackroll_kernel_pkg_indicator) and persistent_list[x] == slackroll_state_new])
+
+            current_kernel_pkgs = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, latest_kernel_pkgs)]]
+            superseded_kernel_pkgs = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if superseded_in(y, auto_kernel_pkgs)]]
+            upgradable_kernel_pkgs = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, auto_kernel_pkgs) and superseded_in(y, latest_kernel_pkgs)]]
+            available_kernel_pkgs = [(x.name, x.version) for x in new_kernel_pkgs]
+
+            print_pairs_or(current_kernel_pkgs, 'Up-to-date kernel packages:', 'No up-to-date kernel packages')
+            print_pairs_or(upgradable_kernel_pkgs, 'Upgradable kernel packages (would be updated by kernel-upgrade):', 'No upgradable kernel packages')
+            print_pairs_or(superseded_kernel_pkgs, 'Superseded kernel packages (would be removed by kernel-clean):', 'No superseded kernel packages')
+            print_pairs_or(manual_kernel_pkgs, 'Manually managed kernel packages (frozen or foreign):', 'No manually managed kernel packages')
+            print_pairs_or(available_kernel_pkgs, 'Other available kernel packages:', 'No other kernel packages available for installation or upgrade')
+            sys.exit()
+
         if operation == 'kernel-clean':
-            outdated_kernel_pkgs = [[y for y in local_list[x] if y not in remote_list[x]]
-                    for x in local_list if x.startswith(slackroll_kernel_pkg_indicator) and persistent_list[x] == slackroll_state_installed]
-            outdated_kernel_pkgs = concat(outdated_kernel_pkgs)
+            # BCS: revised logic to remove all but the latest installed version of a kernel- package.
+            # The old logic removed any versions that did not match the latest available in the repo.
+            # This required all local kernel packages to be up-to-date against the repo before running
+            # the kernel-clean operation (or else risk having no installed version of a key package).
+            # The new logic ensures that the only installed version of a kernel package will never
+            # inadvertently be removed by a kernel-clean operation, and allows the user to safely run
+            # kernel-clean at any time, instead of only after a successful kernel-upgrade.
+            auto_kernel_pkgs = concat([local_list[x] for x in local_list if x.startswith(slackroll_kernel_pkg_indicator) and (persistent_list[x] == slackroll_state_installed or persistent_list[x] == slackroll_state_outdated)])
+            outdated_kernel_pkgs = [x for x in auto_kernel_pkgs if superseded_in(x, auto_kernel_pkgs)]
             if len(outdated_kernel_pkgs) == 0:
-                print('No obsolete kernel packages found')
+                print 'No obsolete kernel packages found'
                 sys.exit()
+            print_pairs_or([(x.name, x.version) for x in outdated_kernel_pkgs], 'Superseded kernel packages to be removed:', 'No superseded kernel packages to remove')
+            if "kernel-source" in [x.name for x in outdated_kernel_pkgs]:
+                print "You may wish to run a 'make clean' or 'make distclean' in kernel source directories before removing the package"
+            maybe_confirm_continue()
             remove_pkgs(outdated_kernel_pkgs)
             post_kernel_operation()
             sys.exit()
 
-        if operation == 'name-search':
+        if operation in ['name-search', 'search-name']:
             all_regexes = '|'.join('(?:%s)' % x for x in args)
             try:
                 regexp = re.compile(all_regexes)
@@ -2652,7 +2737,7 @@ if __name__ == "__main__":
             print_in_states_or(slackroll_all_states, plist_subset, 'Matching packages:', 'No matching packages found', True)
             sys.exit()
 
-        if operation == 'path-search':
+        if operation in ['path-search', 'search-path']:
             all_regexes = '|'.join('(?:%s)' % x for x in args)
             try:
                 regexp = re.compile(all_regexes)

--- a/slackroll
+++ b/slackroll
@@ -644,7 +644,11 @@ def try_dump(object, filepath): # pickle.dump()
 
 def try_load(filepath): # pickle.load()
     try:
-        return pickle.load(open(filepath, 'rb'))
+        if PY2:
+            return pickle.load(open(filepath, 'rb'))
+        else:
+            # BCS: in case DB was written by a Python 2 instance and contains non-ASCII characters
+            return pickle.load(open(filepath, 'rb'), encoding='Latin1')
     except (OSError, IOError, pickle.PickleError) as err:
         sys.exit('ERROR: %s' % err)
 
@@ -1164,10 +1168,10 @@ def update_changelog(mirror, full=False): # Returns answer to "has it been updat
     try:
         conn = urllib.request.urlopen(changelog_url)
         while True:
-            new_line = conn.readline()
+            new_line = interpret_as_str(conn.readline())
             if len(new_line) == 0 or new_line.strip() in limits:
                 break
-            lines.append(interpret_as_str(new_line))
+            lines.append(new_line)
         conn.close()
     except (OSError, IOError, socket.error, urllib.error.ContentTooShortError) as err:
         sys.exit('\nERROR: %s' % err)

--- a/slackroll
+++ b/slackroll
@@ -1957,8 +1957,7 @@ if __name__ == "__main__":
             args = args[1:]
             verify_operation_and_args(op_num_args, operation, args)
 
-        handle_writable_dir(slackroll_base_dir)
-
+        # The following operations do not require a writable /var/slackroll (i.e. don't have to be root)
         if operation == 'help':
             if len(args) == 0:
                 helpname = '00-default'
@@ -1979,6 +1978,9 @@ if __name__ == "__main__":
         if operation == 'print-blacklist':
             print_blacklist()
             sys.exit()
+
+        # Everything after this point *does* require a writable /var/slackroll
+        handle_writable_dir(slackroll_base_dir)
 
         if operation == 'blacklist-add':
             add_blacklist_exprs(args)

--- a/slackroll
+++ b/slackroll
@@ -1172,7 +1172,7 @@ def print_pairs_or(the_list, header, message_on_empty):
 def superseded_in(pkg, the_list):
     name = pkg.name
     old_version = version.parse(pkg.version)
-    newer_pkgs = [x for x in the_list if x.name == name and version.parse(x.version) > old_version]
+    newer_pkgs = [x for x in the_list if x.name == name and (version.parse(x.version) > old_version or version.parse(x.version) == old_version and x.build > pkg.build)]
     return len(newer_pkgs) > 0
 
 def tr_pkg_detail(local_list, remote_list, persistent_list, pkg_name): # Returns a string with package details for a transient package
@@ -2406,7 +2406,6 @@ if __name__ == "__main__":
                 print('No packages with alternative versions')
                 sys.exit()
 
-<<<<<<< HEAD
             names = list(alternatives.keys())
             names.sort(key=functools.cmp_to_key(pkg_name_cmp))
             interceptor = SlackrollOutputInterceptor()
@@ -2418,130 +2417,6 @@ if __name__ == "__main__":
                 print()
             print('End of list')
             interceptor.stop()
-=======
-    if operation in ['list-outdated', 'list-unavailable', 'list-installed', 'list-not-installed', 'list-frozen', 'list-foreign']:
-        state_str = operation.replace('list-', '')
-        header = '%s packages:' % state_str.capitalize()
-        empty_message = 'No %s packages found' % state_str
-        state = slackroll_state_strings.index(state_str)
-
-        interceptor = SlackrollOutputInterceptor()
-        print_in_states_or([state], persistent_list, header, empty_message, False)
-        if state in slackroll_transient_states:
-            maybe_print_key_pkg_watchout(persistent_list)
-        interceptor.stop()
-        sys.exit()
-
-    # BCS: see packages that might have been previously marked as foreign, but are now available in the repo,
-    #      or that were manually frozen, but could be upgraded if unfrozen
-    if operation in ['foreign-upgradable', 'foreign-upgradeable', 'frozen-upgradable', 'frozen-upgradeable']:
-        state_str = operation.replace('-upgradable', '').replace('-upgradeable', '')
-        state = slackroll_state_strings.index(state_str)
-        header = 'Upgradable %s packages:' % state_str
-        empty_message = 'No upgradable %s packages found' % state_str
-
-        local_pkgs = concat([local_list[x] for x in local_list if persistent_list[x] == state])
-        repo_pkgs = concat([remote_list[x] for x in remote_list if persistent_list[x] == state])
-        newer_available_pkgs = [x for x in local_pkgs if superseded_in(x, repo_pkgs)]
-
-        interceptor = SlackrollOutputInterceptor()
-        print_pairs_or([(x.name, x.version + ' installed, ' + ', '.join([y.version for y in repo_pkgs if y.name == x.name]) + ' available') for x in newer_available_pkgs], header, empty_message)
-        interceptor.stop()
-        sys.exit()
-
-    if operation == 'list-local':
-        print_seq_or(local_list, 'Local packages:', 'No local packages found')
-        sys.exit()
-
-    if operation == 'list-remote':
-        print_seq_or(remote_list, 'Remote packages:', 'No remote packages found')
-        sys.exit()
-
-    if operation == 'list-all':
-        print_seq_or(persistent_list, 'All packages:', 'No packages found')
-        sys.exit()
-
-    if operation == 'new-not-installed':
-        new_packages = pkgs_in_state(persistent_list, [slackroll_state_new])
-        from_states_to_state([slackroll_state_new], slackroll_state_notinstalled, persistent_list, new_packages)
-        sys.exit()
-
-    if operation == 'unavailable-foreign':
-        unavailable_packages = pkgs_in_state(persistent_list, [slackroll_state_unavailable])
-        from_states_to_state([slackroll_state_unavailable], slackroll_state_foreign, persistent_list, unavailable_packages)
-        sys.exit()
-
-    if operation in ['frozen', 'freeze']:
-        valid_origins = [slackroll_state_frozen, slackroll_state_installed, slackroll_state_outdated]
-        from_states_to_state(valid_origins, slackroll_state_frozen, persistent_list, args)
-        sys.exit()
-
-    if operation == 'foreign':
-        from_states_to_state([slackroll_state_foreign, slackroll_state_unavailable], slackroll_state_foreign, persistent_list, args)
-        sys.exit()
-
-    if operation == 'not-installed':
-        from_states_to_state([slackroll_state_notinstalled, slackroll_state_new], slackroll_state_notinstalled, persistent_list, args)
-        sys.exit()
-
-    if operation == 'unavailable':
-        from_states_to_state([slackroll_state_unavailable, slackroll_state_foreign], slackroll_state_unavailable, persistent_list, args)
-        sys.exit()
-
-    if operation == 'new':
-        from_states_to_state([slackroll_state_new, slackroll_state_notinstalled], slackroll_state_new, persistent_list, args)
-        sys.exit()
-
-    if operation in ['installed', 'unfreeze']:
-        from_states_to_state([slackroll_state_installed, slackroll_state_frozen], slackroll_state_installed, persistent_list, args)
-        analyze_changes(local_list, remote_list, persistent_list) # Forced because it may need to be marked as outdated
-        os.utime(slackroll_persistentlist_filename, None)
-        sys.exit()
-
-    if operation == 'list-versions':
-        maybe_error_unknown_packages(args, persistent_list)
-        interceptor = SlackrollOutputInterceptor()
-        print 'Available versions:'
-        for name in args:
-            print '    %s:' % name
-            if name in local_list:
-                print '\n'.join('\tLocal:\t%s' % ver.archivename for ver in local_list[name])
-            if name in remote_list:
-                print '\n'.join('\tRemote:\t%s' % ver.fullname for ver in remote_list[name])
-            print
-        print 'End of list'
-        interceptor.stop()
-        sys.exit()
-
-    if operation in ['install', 'reinstall', 'download', 'info', 'urls']:
-        install_operations_family(operation, args, local_list, remote_list, persistent_list)
-        sys.exit()
-
-    if operation in ['install-new', 'download-new', 'info-new', 'urls-new']:
-        names = pkgs_in_state(persistent_list, [slackroll_state_new])
-        names.sort(cmp=pkg_name_cmp)
-        if len(names) == 0:
-            print 'No new packages'
-            sys.exit()
-        opname = operation.replace('-new', '')
-        install_operations_family(opname, names, local_list, remote_list, persistent_list)
-        sys.exit()
-
-    if operation in ['install-path', 'download-path', 'info-path', 'urls-path', 'remove-path']:
-        all_regexes = '|'.join('(?:%s)' % x for x in args)
-        try:
-            regexp = re.compile(all_regexes)
-        except re.error:
-            sys.exit('ERROR: invalid regular expression')
-
-        matching_pkgs = [x for x in concat([remote_list[x] for x in remote_list]) if regexp.search(x.path) is not None]
-
-        if operation == 'remove-path': # Filter out packages not present in local system
-            matching_pkgs = [x for x in matching_pkgs if pkg_in_map(x, local_list)]
-
-        if len(matching_pkgs) == 0:
-            print 'No matching packages'
->>>>>>> f7fbc84 (Improved foreign-upgradable/frozen-upgradable to show installed and available versions.)
             sys.exit()
 
         # BCS: easier access to info files for interesting package categories
@@ -2819,12 +2694,12 @@ if __name__ == "__main__":
             new_kernel_pkgs = concat([remote_list[x] for x in remote_list if x.startswith(slackroll_kernel_pkg_indicator) and persistent_list[x] == slackroll_state_new])
 
             auto_kernel_pkg_names = [x.name for x in auto_kernel_pkgs]
-            current_list = [(x.name, x.version) for x in auto_kernel_pkgs if not superseded_in(x, latest_kernel_pkgs)]
-            superseded_list = [(x.name, x.version) for x in auto_kernel_pkgs if superseded_in(x, auto_kernel_pkgs)]
-            upgradable_list = [(x.name, x.version) for x in latest_kernel_pkgs if x.name in auto_kernel_pkg_names and x not in auto_kernel_pkgs]
-            keeper_list = [(x.name, x.version) for x in auto_kernel_pkgs if not superseded_in(x, auto_kernel_pkgs) and (x.name, x.version) not in current_list]
-            manual_list = [(x.name, x.version) for x in manual_kernel_pkgs]
-            available_list = [(x.name, x.version) for x in new_kernel_pkgs]
+            current_list = [(x.name, x.version + '-' + x.build) for x in auto_kernel_pkgs if not superseded_in(x, latest_kernel_pkgs)]
+            superseded_list = [(x.name, x.version + '-' + x.build) for x in auto_kernel_pkgs if superseded_in(x, auto_kernel_pkgs)]
+            upgradable_list = [(x.name, x.version + '-' + x.build) for x in latest_kernel_pkgs if x.name in auto_kernel_pkg_names and x not in auto_kernel_pkgs]
+            keeper_list = [(x.name, x.version + '-' + x.build) for x in auto_kernel_pkgs if not superseded_in(x, auto_kernel_pkgs) and (x.name, x.version) not in current_list]
+            manual_list = [(x.name, x.version + '-' + x.build) for x in manual_kernel_pkgs]
+            available_list = [(x.name, x.version + '-' + x.build) for x in new_kernel_pkgs]
 
             print_pairs_or(current_list, 'Up-to-date kernel packages:', 'No up-to-date kernel packages')
             print_pairs_or(upgradable_list, 'Newly available versions of kernel packages (would be installed by kernel-upgrade):', 'No upgradable kernel packages')
@@ -2847,7 +2722,7 @@ if __name__ == "__main__":
             if len(outdated_kernel_pkgs) == 0:
                 print 'No obsolete kernel packages found'
                 sys.exit()
-            print_pairs_or([(x.name, x.version) for x in outdated_kernel_pkgs], 'Superseded kernel packages to be removed:', 'No superseded kernel packages to remove')
+            print_pairs_or([(x.name, x.version + '-' + x.build) for x in outdated_kernel_pkgs], 'Superseded kernel packages to be removed:', 'No superseded kernel packages to remove')
             if "kernel-source" in [x.name for x in outdated_kernel_pkgs]:
                 print "You may wish to run a 'make clean' or 'make distclean' in kernel source directories before removing the package"
             maybe_confirm_continue()

--- a/slackroll
+++ b/slackroll
@@ -64,6 +64,7 @@ from functools import reduce
 from packaging import version
 
 from tempfile import mkdtemp
+from packaging import version
 
 # BCS: Pickle protocols > 2 will not be backward-compatible with Python 2
 pickle_protocol = 2

--- a/slackroll
+++ b/slackroll
@@ -2693,14 +2693,15 @@ if __name__ == "__main__":
             latest_kernel_pkgs = concat([remote_list[x] for x in remote_list if x.startswith(slackroll_kernel_pkg_indicator) and not (persistent_list[x] == slackroll_state_frozen or persistent_list[x] == slackroll_state_foreign)])
             new_kernel_pkgs = concat([remote_list[x] for x in remote_list if x.startswith(slackroll_kernel_pkg_indicator) and persistent_list[x] == slackroll_state_new])
 
-            current_list = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, latest_kernel_pkgs)]]
-            superseded_list = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if superseded_in(y, auto_kernel_pkgs)]]
-            upgradable_list = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, auto_kernel_pkgs) and superseded_in(y, latest_kernel_pkgs)]]
+            auto_kernel_pkg_names = [x.name for x in auto_kernel_pkgs]
+            current_list = [(x.name, x.version) for x in auto_kernel_pkgs if not superseded_in(x, latest_kernel_pkgs)]
+            superseded_list = [(x.name, x.version) for x in auto_kernel_pkgs if superseded_in(x, auto_kernel_pkgs)]
+            upgradable_list = [(x.name, x.version) for x in latest_kernel_pkgs if x.name in auto_kernel_pkg_names and x not in auto_kernel_pkgs]
             manual_list = [(x.name, x.version) for x in manual_kernel_pkgs]
             available_list = [(x.name, x.version) for x in new_kernel_pkgs]
 
             print_pairs_or(current_list, 'Up-to-date kernel packages:', 'No up-to-date kernel packages')
-            print_pairs_or(upgradable_list, 'Upgradable kernel packages (would be updated by kernel-upgrade):', 'No upgradable kernel packages')
+            print_pairs_or(upgradable_list, 'Upgradable kernel packages (would be installed by kernel-upgrade):', 'No upgradable kernel packages')
             print_pairs_or(superseded_list, 'Superseded kernel packages (would be removed by kernel-clean):', 'No superseded kernel packages')
             print_pairs_or(manual_list, 'Manually managed kernel packages (frozen or foreign):', 'No manually managed kernel packages')
             print_pairs_or(available_list, 'Other available kernel packages:', 'No other kernel packages available for installation or upgrade')

--- a/slackroll
+++ b/slackroll
@@ -2693,16 +2693,17 @@ if __name__ == "__main__":
             latest_kernel_pkgs = concat([remote_list[x] for x in remote_list if x.startswith(slackroll_kernel_pkg_indicator) and not (persistent_list[x] == slackroll_state_frozen or persistent_list[x] == slackroll_state_foreign)])
             new_kernel_pkgs = concat([remote_list[x] for x in remote_list if x.startswith(slackroll_kernel_pkg_indicator) and persistent_list[x] == slackroll_state_new])
 
-            current_kernel_pkgs = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, latest_kernel_pkgs)]]
-            superseded_kernel_pkgs = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if superseded_in(y, auto_kernel_pkgs)]]
-            upgradable_kernel_pkgs = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, auto_kernel_pkgs) and superseded_in(y, latest_kernel_pkgs)]]
-            available_kernel_pkgs = [(x.name, x.version) for x in new_kernel_pkgs]
+            current_list = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, latest_kernel_pkgs)]]
+            superseded_list = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if superseded_in(y, auto_kernel_pkgs)]]
+            upgradable_list = [(x.name, x.version) for x in [y for y in auto_kernel_pkgs if not superseded_in(y, auto_kernel_pkgs) and superseded_in(y, latest_kernel_pkgs)]]
+            manual_list = [(x.name, x.version) for x in manual_kernel_pkgs]
+            available_list = [(x.name, x.version) for x in new_kernel_pkgs]
 
-            print_pairs_or(current_kernel_pkgs, 'Up-to-date kernel packages:', 'No up-to-date kernel packages')
-            print_pairs_or(upgradable_kernel_pkgs, 'Upgradable kernel packages (would be updated by kernel-upgrade):', 'No upgradable kernel packages')
-            print_pairs_or(superseded_kernel_pkgs, 'Superseded kernel packages (would be removed by kernel-clean):', 'No superseded kernel packages')
-            print_pairs_or(manual_kernel_pkgs, 'Manually managed kernel packages (frozen or foreign):', 'No manually managed kernel packages')
-            print_pairs_or(available_kernel_pkgs, 'Other available kernel packages:', 'No other kernel packages available for installation or upgrade')
+            print_pairs_or(current_list, 'Up-to-date kernel packages:', 'No up-to-date kernel packages')
+            print_pairs_or(upgradable_list, 'Upgradable kernel packages (would be updated by kernel-upgrade):', 'No upgradable kernel packages')
+            print_pairs_or(superseded_list, 'Superseded kernel packages (would be removed by kernel-clean):', 'No superseded kernel packages')
+            print_pairs_or(manual_list, 'Manually managed kernel packages (frozen or foreign):', 'No manually managed kernel packages')
+            print_pairs_or(available_list, 'Other available kernel packages:', 'No other kernel packages available for installation or upgrade')
             sys.exit()
 
         if operation == 'kernel-clean':

--- a/slackroll
+++ b/slackroll
@@ -16,8 +16,6 @@
 #
 
 from __future__ import print_function
-from past.builtins import cmp
-
 from future import standard_library
 
 # Avoid Python 2 exception when calling install_aliases() from a directory that no longer exists
@@ -42,6 +40,11 @@ debug_output = True
 
 PY2 = sys.version_info[0] <= 2
 
+# DEPRECATED, but support the SlackwarePackage.__cmp__() method
+if not PY2:
+    from past.builtins import cmp
+
+# Select an appropriate DB backend
 if PY2:
     import anydbm
     anydbm._defaultmod = __import__('gdbm')
@@ -99,7 +102,6 @@ import urllib.request, urllib.parse, urllib.error
 import urllib.parse
 from functools import reduce
 from tempfile import mkdtemp
-from packaging import version
 
 # BCS: Pickle protocols > 2 will not be backward-compatible with Python 2
 pickle_protocol = 2
@@ -1349,10 +1351,47 @@ def print_pairs_or(the_list, header, message_on_empty):
         print(' %s (%s)' % (a, b))
     interceptor.stop()
 
+# Break a version string into a list of (string) components separated by . or - or +
+# This is NOT as strict as the standard packaging.version library or PEP 440, but the
+# additional flexibility is required to handle packages that use hexadecimal hash numbers
+# and/or underscores as part of the version string (as many SlackBuilds do).
+# slackware-current's latest version of python-packaging (24.0 for Python 3.11) will throw
+# an exception on such strings.
+def str_to_version_list(s):
+    return re.split("\.|-|\+", s)
+
+# Compare two lists representing the components of a version string. Uses numerical comparison if
+# two elements in the same position are both decimal digit strings (e.g. so "11" will test as
+# less than "101", otherwise tests in lexicographical order (so "b101" tests as less than "b11").
+def version_list_cmp(v1, v2):
+    if not v1 and not v2:
+        return 0
+    elif v1 and not v2:
+        return 1
+    elif v2 and not v1:
+        return -1
+
+    if v1[0].isdigit() and v2[0].isdigit():
+        key1, key2 = int(v1[0]), int(v2[0])
+    else:
+        key1, key2 = v1[0], v2[0]
+    if key1 == key2:
+        return version_list_cmp(v1[1:], v2[1:])
+    elif key1 < key2:
+        return -1
+    else:
+        return 1
+
+def versions_equal(str1, str2):
+    return version_list_cmp(str_to_version_list(str1), str_to_version_list(str2)) == 0
+
+def first_is_newer(str1, str2):
+    return version_list_cmp(str_to_version_list(str1), str_to_version_list(str2)) > 0
+
+# True iff the given package has a newer version available in the provided list
 def superseded_in(pkg, the_list):
     name = pkg.name
-    old_version = version.parse(pkg.version)
-    newer_pkgs = [x for x in the_list if x.name == name and (version.parse(x.version) > old_version or version.parse(x.version) == old_version and x.build > pkg.build)]
+    newer_pkgs = [x for x in the_list if x.name == name and (first_is_newer(x.version, pkg.version) or versions_equal(x.version, pkg.version) and x.build > pkg.build)]
     return len(newer_pkgs) > 0
 
 def tr_pkg_detail(local_list, remote_list, persistent_list, pkg_name): # Returns a string with package details for a transient package

--- a/slackroll
+++ b/slackroll
@@ -252,18 +252,6 @@ def transient_key(name_state):
         group = -1
     return (priority, group, name)
 
-# BCS: This function is NO LONGER USED after the conversion to key-style sorting.
-# However, it is required for a test in the current CI pipeline.
-# It can safely be deleted after pull request #22 is merged.
-def transient_cmp(name_state1, name_state2): # Special sort for transient list
-    (name1, state1) = name_state1
-    (name2, state2) = name_state2
-    if name1 in slackroll_prioritized_pkgs or name2 in slackroll_prioritized_pkgs:
-        return pkg_name_cmp(name1, name2)
-    if state1 != state2:
-        return (index_of(slackroll_transient_states, state1) - index_of(slackroll_transient_states, state2))
-    return cmp(name1, name2)
-
 class SlackrollError(Exception):
     pass
 

--- a/slackroll
+++ b/slackroll
@@ -27,6 +27,7 @@ from builtins import object
 from builtins import range
 from builtins import str
 
+import io
 import sys
 
 PY2 = sys.version_info[0] <= 2
@@ -38,6 +39,15 @@ if PY2:
     import bsddb
 else:
     import dbm
+
+# Workaround for Unicode/bytestring handling differences between Python 2 and 3
+default_output_encoding = "UTF-8"
+if PY2:
+    def print(message=""):
+        write_to_pipe(sys.stdout, message + "\n")
+    import collections
+else:
+    sys.stdout = io.open(sys.stdout.fileno(), mode='w', encoding=default_output_encoding, buffering=1)
 
 import bz2
 import pickle
@@ -186,7 +196,14 @@ def index_of(thelist, elem):
     except ValueError:
         return -1
 
-def pkg_name_cmp(name1, name2): # To be used for sorting functions
+def pkg_name_key(name):
+    # Used for sorting: packages in the prioritized list wind up ahead of others in the sorted output
+    priority = index_of(slackroll_prioritized_pkgs, name)
+    if priority < 0:
+        priority = len(slackroll_prioritized_pkgs)
+    return (priority, name)
+
+def pkg_name_cmp(name1, name2): # DEPRECATED; maintained only to provide SlackwarePackage.__cmp__()
     idx1 = index_of(slackroll_prioritized_pkgs, name1)
     idx2 = index_of(slackroll_prioritized_pkgs, name2)
 
@@ -198,14 +215,16 @@ def pkg_name_cmp(name1, name2): # To be used for sorting functions
         return -1
     return (idx1 - idx2)
 
-def transient_cmp(name_state1, name_state2): # Special sort for transient list
-    (name1, state1) = name_state1
-    (name2, state2) = name_state2
-    if name1 in slackroll_prioritized_pkgs or name2 in slackroll_prioritized_pkgs:
-        return pkg_name_cmp(name1, name2)
-    if state1 != state2:
-        return (index_of(slackroll_transient_states, state1) - index_of(slackroll_transient_states, state2))
-    return cmp(name1, name2)
+def transient_key(name_state):
+    # Special sort key for list-transient: group packages by state, sorted by name within each group
+    (name, state) = name_state
+    priority = index_of(slackroll_prioritized_pkgs, name)
+    if priority < 0:
+        priority = len(slackroll_prioritized_pkgs)
+        group = index_of(slackroll_transient_states, state)
+    else:
+        group = -1
+    return (priority, group, name)
 
 class SlackrollError(Exception):
     pass
@@ -400,8 +419,53 @@ def clentrylist_from_text(text):
     entries = [x for x in entries if len(x) > 0]
     return [clentry_from_text(x) for x in entries]
 
-def print_flush(message):
-    sys.stdout.write(message)
+# dbm on Python 2 only accepts encoded strings as keys, not general Unicode
+def to_dbkey(x):
+    if isinstance(x, str):
+        return x
+    return x.encode(default_output_encoding)
+
+# Attempt to determine/use the system-set encoding for the given file or pipe
+def output_encoding(stream):
+    try:
+        if stream.encoding is None:
+            return default_output_encoding
+        else:
+            return stream.encoding
+    except (AttributeError, TypeError):
+        pass
+    return default_output_encoding
+
+# Consolidate writes in one place to handle string/representation conversions between Python 2 & 3
+# Use force_encoding when the source of the text was itself a pipe (e.g. pager program)
+def write_to_pipe(fd, text, force_encoding=False):
+    preferred_encoding = output_encoding(fd)
+    if PY2:
+        # Provide some backup options in case the detected encoding is limited (e.g. pager stdin pipe will probably report 'ascii')
+        trial_encodings = collections.deque()
+        for i in [preferred_encoding, "latin_1", "UTF-8", "unicode_internal"]:
+            if i not in trial_encodings:
+                trial_encodings.append(i)
+        while len(trial_encodings) > 0: 
+            encoding = trial_encodings.popleft()
+            try:
+                if force_encoding:
+                    fd.write(text.encode(encoding))
+                else:
+                    fd.write(text.decode(encoding))
+                return
+            except UnicodeEncodeError:
+                if len(trial_encodings) > 0:
+                    continue
+                else:
+                    raise
+    elif force_encoding:
+        fd.write(text.encode(preferred_encoding))
+    else:
+        fd.write(text)
+
+def print_flush(message=""):
+    write_to_pipe(sys.stdout, message)
     sys.stdout.flush()
 
 def concat(list_of_lists):
@@ -442,14 +506,14 @@ def enough_fs_resources(numpkgs, bytes): # Check if there are enough filesystem 
 
 def get_self_file_version(): # Get self version from disk file
     try:
-        data = open(slackroll_self_filename, 'r').read()
+        data = io.open(slackroll_self_filename, 'r').read()
         return int(data)
     except (OSError, IOError, ValueError) as err:
         sys.exit('ERROR: %s' % err)
 
 def write_self_file_version(): # Write self version to disk file
     try:
-        open(slackroll_self_filename, 'w').write('%s\n' % slackroll_version)
+        io.open(slackroll_self_filename, 'w').write(str(slackroll_version) + '\n')
     except (OSError, IOError) as err:
         sys.exit('ERROR: %s' % err)
 
@@ -549,10 +613,19 @@ def print_blacklist():
     numbered = ['%-4s  %s' % (x, bl[x]) for x in range(len(bl))]
     print_list_or(numbered, 'Blacklisted expressions:', 'No blacklisted expressions')
 
+def clean_filename(s, encoding="latin1"):
+    if PY2:
+        return s.strip().decode('string_escape')
+    else:
+        if encoding == "latin1":
+            return s.strip().encode(encoding).decode("unicode_escape")
+        else:
+            return s.strip().encode(encoding).decode("unicode_escape").encode("latin1").decode(encoding)
+
 def extract_file_list(filename): # Extracts the file list from a local info file
     try:
-        lines = open(filename, 'r').readlines()
-        paths = ['/%s' % x.strip().decode('string_escape') for x in lines[lines.index(slackroll_local_pkg_filelist_marker) + 1:]]
+        lines = io.open(filename, 'r', encoding="unicode_escape").readlines()
+        paths = ['/%s' % clean_filename(x) for x in lines[lines.index(slackroll_local_pkg_filelist_marker) + 1:]]
         return paths
     except ValueError:
         sys.exit('ERROR: unable to find file list marker in %s' % filename)
@@ -614,7 +687,7 @@ def get_local_list(forced_rebuild): # Return list of local packages from cached 
 
 def get_remote_pkgs(local_filelist, url): # Return a list of packages from FILELIST.TXT
     try:
-        lines = open(local_filelist, 'r').readlines()
+        lines = io.open(local_filelist, 'r', encoding="unicode_escape").readlines()
         matches = [slackroll_filelist_pkg_re.match(x) for x in lines]
         nm_sz = [(x.group(slackroll_filelist_pkg_str), x.group(slackroll_filelist_pkg_size)) for x in matches if x is not None]
         return [pkg_from_name_size_url(nm, sz, url) for (nm, sz) in nm_sz if slackroll_source_indicator not in nm]
@@ -651,7 +724,7 @@ def get_remote_list(): # Return list of remote packages from cached list, updati
 def get_mirror_from_file(filepath):
     try:
         filename = os.path.basename(filepath)
-        lines = open(filepath, 'r').readlines()
+        lines = io.open(filepath, 'r', encoding="unicode_escape").readlines()
         if len(lines) != 1:
             raise ValueError('more than one line on %s file' % filename)
         mirror = lines[0].strip()
@@ -683,7 +756,7 @@ def set_mirror(mirror): # Writes the mirror name to the 'mirror' file
     if not mirror.endswith('/'):
         mirror = mirror + '/'
     try:
-        open(slackroll_mirror_filename, 'w').write('%s\n' % mirror)
+        io.open(slackroll_mirror_filename, 'w', encoding=default_output_encoding).write('%s\n' % mirror)
     except (OSError, IOError, ValueError) as err:
         sys.exit('ERROR: %s' % err)
 
@@ -691,7 +764,7 @@ def set_primary_mirror(mirror): # Writes the mirror name to the 'pmirror' file
     if not mirror.endswith('/'):
         mirror = mirror + '/'
     try:
-        open(slackroll_primary_mirror_filename, 'w').write('%s\n' % mirror)
+        io.open(slackroll_primary_mirror_filename, 'w', encoding=default_output_encoding).write('%s\n' % mirror)
     except (OSError, IOError, ValueError) as err:
         sys.exit('ERROR: %s' % err)
 
@@ -771,17 +844,17 @@ class SlackrollOutputInterceptor(object): # Intercepts stdout and uses a pager i
         numlines = output.count('\n')
         if needs_pager(numlines):
             proc = call_pager()
-            proc.stdin.write(output)
+            write_to_pipe(proc.stdin, output, True)
             proc.stdin.close()
             proc.wait()
         else:
-            sys.stdout.write(output)
+            write_to_pipe(sys.stdout, output)
 
 def run_program(arg_list, env=None): # Does not exit on errors
     try:
         subprocess.call(arg_list, env=env)
     except (OSError, IOError) as err:
-        sys.stderr.write('ERROR: %s\n' % err)
+        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
 
 def run_visual_on(file_path): # Does not exit on errors
     run_program(get_visual().split() + [file_path])
@@ -796,7 +869,7 @@ def try_to_remove(file_path, fatal=True): # When it returns, it is True if file 
         os.remove(file_path)
         return True
     except (OSError, IOError) as err:
-        sys.stderr.write('ERROR: %s\n' % err)
+        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
         if fatal:
             sys.exit(slackroll_exit_failure)
         return False
@@ -806,7 +879,7 @@ def try_to_rename(src, dest, fatal=True): # When it returns, it is True if file 
         os.rename(src, dest)
         return True
     except (OSError, IOError) as err:
-        sys.stderr.write('ERROR: %s\n' % err)
+        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
         if fatal:
             sys.exit(slackroll_exit_failure)
         return False
@@ -825,14 +898,14 @@ def download_file(mirror, filepath, local_temp, local_final, displayed_name=None
         if displayed_name is None:
             displayed_name = os.path.basename(filepath)
         print_flush('Downloading %s ... ' % displayed_name)
-        full_url = urllib.parse.urljoin(mirror, filepath)
+        full_url = urllib.parse.urljoin(str(mirror), str(filepath))
         hook = None if slackroll_batch_mode else functools.partial(download_report_hook, displayed_name)
         urllib.request.urlretrieve(full_url, local_temp, hook)
         print()
         if not try_to_rename(local_temp, local_final, fatal=False):
             raise SlackrollError('rename error: %s => %s' % (local_temp, local_final))
     except (OSError, IOError, socket.error, urllib.error.ContentTooShortError) as err:
-        sys.stderr.write('\nERROR: %s\n' % err)
+        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
         raise SlackrollError(str(err))
 
 def download(mirror, filepath, localdir, displayed_name=None): # Wrapper that does NOT exit on errors
@@ -886,10 +959,10 @@ def verify_signature(filename):    # Does not exit on errors
         print('Verifying signature %s ... ' % os.path.basename(filename))
         retcode = subprocess.call([gnupg_exec_name, '--verify', filename], stdout=open(os.path.devnull, 'w'), stderr=subprocess.STDOUT)
         if retcode != 0:
-            sys.stderr.write('ERROR: signature verification failed: %s\n' % filename)
+            write_to_pipe(sys.stderr, 'ERROR: signature verification failed: %s\n' % filename)
             raise SlackrollError('GnuPG exited with status code %s' % retcode)
     except (OSError, IOError) as err:
-        sys.stderr.write('ERROR: %s\n' % err)
+        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
         raise SlackrollError(str(err))
 
 def upgrade_or_install(filename, reinstall): # upgradepkg
@@ -964,7 +1037,7 @@ def get_remote_info(mirror, package): # Downloads info file and returns its cont
     remote_file = package.fullname[:-len(slackroll_info_suffix)] + slackroll_info_suffix
     local_file = os.path.join(slackroll_base_dir, os.path.basename(remote_file))
     download_or_exit(package.base_url(mirror), remote_file, slackroll_base_dir)
-    data = open(local_file, 'r').read()
+    data = io.open(local_file, 'r', encoding="unicode_escape").read()
     try_to_remove(local_file)
     return data
 
@@ -973,7 +1046,7 @@ def update_changelog(mirror, full=False): # Returns answer to "has it been updat
         temp_dir = get_temp_dir()
         download_or_exit(mirror, slackroll_changelog_filename, temp_dir)
         local_filename = os.path.join(temp_dir, slackroll_changelog_filename)
-        text = open(local_filename).read()
+        text = io.open(local_filename, 'r', encoding="unicode_escape").read()
         cl = ChangeLog()
         cl.add_entries(clentrylist_from_text(text))
         try_dump(cl, slackroll_local_changelog)
@@ -1060,7 +1133,7 @@ def key_pkg_in(name_list): # Does any name match with a prioritized package?
     return (len(set(slackroll_prioritized_pkgs).intersection(set(name_list))) > 0)
 
 def key_transient_pkgs(persistent_list):
-    return [x for x in slackroll_prioritized_pkgs if x in persistent_list and persistent_list[x] in slackroll_transient_states]
+    return [x for x in slackroll_prioritized_pkgs if to_dbkey(x) in persistent_list and persistent_list[x] in slackroll_transient_states]
 
 def key_pkg_activity_pending(persistent_list): # True if any new, outdated or unavailable package is prioritized
     return (len(key_transient_pkgs(persistent_list)) > 0)
@@ -1104,7 +1177,7 @@ def print_in_states(states, persistent_list, header, print_state): # Print packa
     if len(keys) == 0:
         return
     print(header)
-    keys.sort(key=functools.cmp_to_key(pkg_name_cmp))
+    keys.sort(key=pkg_name_key)
     if print_state:
         fmt = '    %%-%ss  %%s' % max(len(slackroll_state_strings[x]) for x in slackroll_all_states)
         items = [(slackroll_state_strings[persistent_list[x]], x) for x in keys]
@@ -1123,12 +1196,12 @@ def print_in_states_or(states, persistent_list, header, message_on_empty, print_
     print_in_states(states, persistent_list, header, print_state)
     interceptor.stop()
 
-def print_seq(seq, header): # Print every item in sequence, sorted with pkg_name_cmp()
+def print_seq(seq, header): # Print every item in sequence, with priority packages ahead of the others
     if len(seq) == 0:
         return
     print(header)
     items = [x for x in seq]
-    items.sort(key=functools.cmp_to_key(pkg_name_cmp))
+    items.sort(key=pkg_name_key)
     for item in items:
         print('    %s' % item)
     print('End of list')
@@ -1182,9 +1255,9 @@ def tr_pkg_detail(local_list, remote_list, persistent_list, pkg_name): # Returns
     return ' '.join(x.path for x in remote_list[pkg_name])
 
 def error_unknown_packages(name_list): # Print package names as unknown and exit with error
-    sys.stderr.write(''.join('WARNING: %s looks like an unexpected full version\n' % x for x in name_list if may_be_full_version(x)))
-    sys.stderr.write('ERROR: The following packages are unknown:\n')
-    sys.stderr.write(''.join('ERROR:    %s\n' % x for x in name_list))
+    write_to_pipe(sys.stderr, ''.join('WARNING: %s looks like an unexpected full version\n' % x for x in name_list if may_be_full_version(x)))
+    write_to_pipe(sys.stderr, 'ERROR: The following packages are unknown:\n')
+    write_to_pipe(sys.stderr, ''.join('ERROR:    %s\n' % x for x in name_list))
     sys.exit(slackroll_exit_failure)
 
 def maybe_error_unknown_packages(name_list, by_name):
@@ -1233,7 +1306,7 @@ def handle_dotnew_files_installation_batch(dotnew_files): # Handles .new files p
             new_exists = os.path.exists(newfile)
             old_exists = os.path.exists(oldfile)
         except (OSError, IOError) as err:
-            sys.stderr.write('ERROR: %s\n' % err)
+            write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
             break
 
         if new_exists and old_exists: # Both
@@ -1272,7 +1345,7 @@ def handle_dotnew_files_installation_interactive(dotnew_files): # Handles .new f
                 new_exists = os.path.exists(newfile)
                 old_exists = os.path.exists(oldfile)
             except (OSError, IOError) as err:
-                sys.stderr.write('ERROR: %s\n' % err)
+                write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
                 break
 
             print('\n%s %s' % (['Reviewing', 'Still reviewing'][pair_iterations > 1], newfile))
@@ -1591,7 +1664,7 @@ def install_operations_family(operation, args, local_list, remote_list, persiste
         for pkg in chosen_pkgs:
             try:
                 if pkg_in_map(pkg, local_list):
-                    lines = open(pkg.fullname, 'r').readlines()
+                    lines = io.open(pkg.fullname, 'r', encoding="unicode_escape").readlines()
                     header = lines[:lines.index(slackroll_local_pkg_filelist_marker)]
                     info_map[pkg.fullname] = ''.join(header)
                 else:
@@ -1614,7 +1687,7 @@ def install_operations_family(operation, args, local_list, remote_list, persiste
 def extend_manifest_list(manifest_list, index, mirror, local_filelist):
     # Build the list of MANIFEST.bz2 files
     try:
-        lines = open(local_filelist, 'r').readlines()
+        lines = io.open(local_filelist, 'r', encoding="unicode_escape").readlines()
     except (IOError, OSError) as err:
         sys.exit('ERROR: %s' % err)
     files = [slackroll_manifest_re.search(x) for x in lines]
@@ -1745,9 +1818,9 @@ def verify_operation_and_args(op_num_args, operation, args): # Verify number of 
         best_matches.sort()
 
         # Print the error and the list.
-        sys.stderr.write('ERROR: no operation called "%s"\n' % (operation, ))
-        sys.stderr.write('Use the "help" operation to get a list.\n')
-        sys.stderr.write('Did you mean %s?\n' % ' or '.join('"%s"' % ('-'.join(x), ) for x in best_matches))
+        write_to_pipe(sys.stderr, 'ERROR: no operation called "%s"\n' % (operation, ))
+        write_to_pipe(sys.stderr, 'Use the "help" operation to get a list.\n')
+        write_to_pipe(sys.stderr, 'Did you mean %s?\n' % ' or '.join('"%s"' % ('-'.join(x), ) for x in best_matches))
         sys.exit(slackroll_exit_failure)
     else:
         verify_num_args(op_num_args[operation], operation, args)
@@ -1968,7 +2041,7 @@ if __name__ == "__main__":
             if not is_readable_file(helpfile):
                 sys.exit('ERROR: no help found for "%s"' % helpname)
             interceptor = SlackrollOutputInterceptor()
-            print(open(helpfile, 'r').read())
+            print(io.open(helpfile, 'r', encoding="unicode_escape").read())
             interceptor.stop()
             sys.exit()
 
@@ -2272,7 +2345,7 @@ if __name__ == "__main__":
                 maybe_confirm_continue()
 
             names = pkgs_in_state(persistent_list, [slackroll_state_outdated])
-            names.sort(cmp=pkg_name_cmp))
+            names.sort(key=pkg_name_key)
 
             if len(names) == 0:
                 print('No outdated packages')
@@ -2286,7 +2359,7 @@ if __name__ == "__main__":
             sys.exit()
 
         if operation in ['upgrade-key-packages', 'download-key-packages', 'urls-key-packages']:
-            names = [x for x in slackroll_prioritized_pkgs if x in persistent_list and persistent_list[x] == slackroll_state_outdated]
+            names = [x for x in slackroll_prioritized_pkgs if to_dbkey(x) in persistent_list and persistent_list[x] == slackroll_state_outdated]
             if len(names) == 0:
                 print('No outdated key system packages')
                 sys.exit()
@@ -2348,7 +2421,7 @@ if __name__ == "__main__":
             else: # list-outdated-frozen
                 print('Would be outdated:')
 
-            names.sort(key=functools.cmp_to_key(pkg_name_cmp))
+            names.sort(key=pkg_name_key)
             for name in names:
                 candidates = not_pasture(remote_list[name])
                 if len(candidates) == 0:
@@ -2370,7 +2443,7 @@ if __name__ == "__main__":
             if len(pkgs_and_states) == 0:
                 print('No transient packages found')
                 sys.exit()
-            pkgs_and_states.sort(key=functools.cmp_to_key(transient_cmp))
+            pkgs_and_states.sort(key=transient_key)
 
             # Translate states to strings and precalculate constants
             pkgs_and_states = [(name, slackroll_state_strings[state]) for (name, state) in pkgs_and_states]
@@ -2410,7 +2483,7 @@ if __name__ == "__main__":
                 sys.exit()
 
             names = list(alternatives.keys())
-            names.sort(key=functools.cmp_to_key(pkg_name_cmp))
+            names.sort(key=pkg_name_key)
             interceptor = SlackrollOutputInterceptor()
             print('Packages with alternatives:')
             for name in names:
@@ -2430,7 +2503,7 @@ if __name__ == "__main__":
             else:
                 states = [slackroll_state_strings.index(state_str)]
             names = pkgs_in_state(persistent_list, states)
-            names.sort(cmp=pkg_name_cmp)
+            names.sort(key=pkg_name_key)
             if len(names) == 0:
                 print('No %s packages' % state_str)
             else:
@@ -2537,7 +2610,7 @@ if __name__ == "__main__":
 
         if operation in ['install-new', 'download-new', 'info-new', 'urls-new']:
             names = pkgs_in_state(persistent_list, [slackroll_state_new])
-            names.sort(key=functools.cmp_to_key(pkg_name_cmp))
+            names.sort(key=pkg_name_key)
             if len(names) == 0:
                 print('No new packages')
                 sys.exit()
@@ -2577,7 +2650,7 @@ if __name__ == "__main__":
             verify_local_names(args, local_list)
             interceptor = SlackrollOutputInterceptor()
             try:
-                print('\n'.join(open(x.fullname, 'r').read() for x in concat(local_list[pkg] for pkg in args)))
+                print('\n'.join(io.open(x.fullname, 'r', encoding="unicode_escape").read() for x in concat(local_list[pkg] for pkg in args)))
             except (IOError, OSError) as err:
                 sys.exit('ERROR: %s' % err)
             interceptor.stop()
@@ -2587,8 +2660,8 @@ if __name__ == "__main__":
             # Verify readable files
             bad_files = [x for x in args if not is_readable_file(x)]
             if len(bad_files) > 0:
-                sys.stderr.write('ERROR: the following items are not readable files:\n')
-                sys.stderr.write(''.join('ERROR:    %s\n' % x for x in bad_files))
+                write_to_pipe(sys.stderr, 'ERROR: the following items are not readable files:\n')
+                write_to_pipe(sys.stderr, ''.join('ERROR:    %s\n' % x for x in bad_files))
                 sys.exit(slackroll_exit_failure)
 
             # Verify and get package names
@@ -2598,10 +2671,10 @@ if __name__ == "__main__":
                 sys.exit('ERROR: %s' % err)
 
             # The packages must not be present in persistent list or be foreign already
-            bad_pkgs = [x for x in pkgs if x.name in persistent_list and persistent_list[x.name] != slackroll_state_foreign]
+            bad_pkgs = [x for x in pkgs if to_dbkey(x.name) in persistent_list and persistent_list[x.name] != slackroll_state_foreign]
             if len(bad_pkgs) > 0:
-                sys.stderr.write('ERROR: the following packages are known and not foreign\n')
-                sys.stderr.write(''.join('ERROR:    %s\n' % x.name for x in bad_pkgs))
+                write_to_pipe(sys.stderr, 'ERROR: the following packages are known and not foreign\n')
+                write_to_pipe(sys.stderr, ''.join('ERROR:    %s\n' % x.name for x in bad_pkgs))
                 sys.exit(slackroll_exit_failure)
 
             # Get .new files from old packages
@@ -2627,7 +2700,7 @@ if __name__ == "__main__":
             for name in args:
                 if name not in persistent_list:
                     if may_be_full_version(name):
-                        sys.stderr.write('WARNING: %s looks like an unexpected full version\n' % name)
+                        write_to_pipe(sys.stderr, 'WARNING: %s looks like an unexpected full version\n' % name)
                     sys.exit('ERROR: no package named %s' % name)
 
             unavpkg = args[0]
@@ -2757,16 +2830,16 @@ if __name__ == "__main__":
 
     except (KeyboardInterrupt, IOError, EOFError) as error:
         if isinstance(error, KeyboardInterrupt):
-            sys.stderr.write('\nProgram aborted by user\n')
+            write_to_pipe(sys.stderr, '\nProgram aborted by user\n')
         if persistent_list is not None:
             persistent_list.close()
         sys.exit(slackroll_exit_failure)
     except SlackrollBatchModeError:
-        sys.stderr.write('\nProgram aborted because operation could not be completed in batch mode\n')
+        write_to_pipe(sys.stderr, '\nProgram aborted because operation could not be completed in batch mode\n')
         if persistent_list is not None:
             persistent_list.close()
         sys.exit(slackroll_exit_failure)
     except IndexError:
-        sys.stderr.write('ERROR: no operation given\n')
-        sys.stderr.write('Use "help" operation to get a list\n')
+        write_to_pipe(sys.stderr, 'ERROR: no operation given\n')
+        write_to_pipe(sys.stderr, 'Use "help" operation to get a list\n')
         sys.exit(slackroll_exit_failure)

--- a/slackroll
+++ b/slackroll
@@ -19,6 +19,14 @@ from __future__ import print_function
 from past.builtins import cmp
 
 from future import standard_library
+
+# Avoid Python 2 exception when calling install_aliases() from a directory that no longer exists
+import os
+try:
+    dir = os.getcwd()
+except OSError as err:
+    os.chdir("/")
+
 standard_library.install_aliases()
 
 from builtins import input

--- a/slackroll
+++ b/slackroll
@@ -2406,6 +2406,7 @@ if __name__ == "__main__":
                 print('No packages with alternative versions')
                 sys.exit()
 
+<<<<<<< HEAD
             names = list(alternatives.keys())
             names.sort(key=functools.cmp_to_key(pkg_name_cmp))
             interceptor = SlackrollOutputInterceptor()
@@ -2417,6 +2418,130 @@ if __name__ == "__main__":
                 print()
             print('End of list')
             interceptor.stop()
+=======
+    if operation in ['list-outdated', 'list-unavailable', 'list-installed', 'list-not-installed', 'list-frozen', 'list-foreign']:
+        state_str = operation.replace('list-', '')
+        header = '%s packages:' % state_str.capitalize()
+        empty_message = 'No %s packages found' % state_str
+        state = slackroll_state_strings.index(state_str)
+
+        interceptor = SlackrollOutputInterceptor()
+        print_in_states_or([state], persistent_list, header, empty_message, False)
+        if state in slackroll_transient_states:
+            maybe_print_key_pkg_watchout(persistent_list)
+        interceptor.stop()
+        sys.exit()
+
+    # BCS: see packages that might have been previously marked as foreign, but are now available in the repo,
+    #      or that were manually frozen, but could be upgraded if unfrozen
+    if operation in ['foreign-upgradable', 'foreign-upgradeable', 'frozen-upgradable', 'frozen-upgradeable']:
+        state_str = operation.replace('-upgradable', '').replace('-upgradeable', '')
+        state = slackroll_state_strings.index(state_str)
+        header = 'Upgradable %s packages:' % state_str
+        empty_message = 'No upgradable %s packages found' % state_str
+
+        local_pkgs = concat([local_list[x] for x in local_list if persistent_list[x] == state])
+        repo_pkgs = concat([remote_list[x] for x in remote_list if persistent_list[x] == state])
+        newer_available_pkgs = [x for x in local_pkgs if superseded_in(x, repo_pkgs)]
+
+        interceptor = SlackrollOutputInterceptor()
+        print_pairs_or([(x.name, x.version + ' installed, ' + ', '.join([y.version for y in repo_pkgs if y.name == x.name]) + ' available') for x in newer_available_pkgs], header, empty_message)
+        interceptor.stop()
+        sys.exit()
+
+    if operation == 'list-local':
+        print_seq_or(local_list, 'Local packages:', 'No local packages found')
+        sys.exit()
+
+    if operation == 'list-remote':
+        print_seq_or(remote_list, 'Remote packages:', 'No remote packages found')
+        sys.exit()
+
+    if operation == 'list-all':
+        print_seq_or(persistent_list, 'All packages:', 'No packages found')
+        sys.exit()
+
+    if operation == 'new-not-installed':
+        new_packages = pkgs_in_state(persistent_list, [slackroll_state_new])
+        from_states_to_state([slackroll_state_new], slackroll_state_notinstalled, persistent_list, new_packages)
+        sys.exit()
+
+    if operation == 'unavailable-foreign':
+        unavailable_packages = pkgs_in_state(persistent_list, [slackroll_state_unavailable])
+        from_states_to_state([slackroll_state_unavailable], slackroll_state_foreign, persistent_list, unavailable_packages)
+        sys.exit()
+
+    if operation in ['frozen', 'freeze']:
+        valid_origins = [slackroll_state_frozen, slackroll_state_installed, slackroll_state_outdated]
+        from_states_to_state(valid_origins, slackroll_state_frozen, persistent_list, args)
+        sys.exit()
+
+    if operation == 'foreign':
+        from_states_to_state([slackroll_state_foreign, slackroll_state_unavailable], slackroll_state_foreign, persistent_list, args)
+        sys.exit()
+
+    if operation == 'not-installed':
+        from_states_to_state([slackroll_state_notinstalled, slackroll_state_new], slackroll_state_notinstalled, persistent_list, args)
+        sys.exit()
+
+    if operation == 'unavailable':
+        from_states_to_state([slackroll_state_unavailable, slackroll_state_foreign], slackroll_state_unavailable, persistent_list, args)
+        sys.exit()
+
+    if operation == 'new':
+        from_states_to_state([slackroll_state_new, slackroll_state_notinstalled], slackroll_state_new, persistent_list, args)
+        sys.exit()
+
+    if operation in ['installed', 'unfreeze']:
+        from_states_to_state([slackroll_state_installed, slackroll_state_frozen], slackroll_state_installed, persistent_list, args)
+        analyze_changes(local_list, remote_list, persistent_list) # Forced because it may need to be marked as outdated
+        os.utime(slackroll_persistentlist_filename, None)
+        sys.exit()
+
+    if operation == 'list-versions':
+        maybe_error_unknown_packages(args, persistent_list)
+        interceptor = SlackrollOutputInterceptor()
+        print 'Available versions:'
+        for name in args:
+            print '    %s:' % name
+            if name in local_list:
+                print '\n'.join('\tLocal:\t%s' % ver.archivename for ver in local_list[name])
+            if name in remote_list:
+                print '\n'.join('\tRemote:\t%s' % ver.fullname for ver in remote_list[name])
+            print
+        print 'End of list'
+        interceptor.stop()
+        sys.exit()
+
+    if operation in ['install', 'reinstall', 'download', 'info', 'urls']:
+        install_operations_family(operation, args, local_list, remote_list, persistent_list)
+        sys.exit()
+
+    if operation in ['install-new', 'download-new', 'info-new', 'urls-new']:
+        names = pkgs_in_state(persistent_list, [slackroll_state_new])
+        names.sort(cmp=pkg_name_cmp)
+        if len(names) == 0:
+            print 'No new packages'
+            sys.exit()
+        opname = operation.replace('-new', '')
+        install_operations_family(opname, names, local_list, remote_list, persistent_list)
+        sys.exit()
+
+    if operation in ['install-path', 'download-path', 'info-path', 'urls-path', 'remove-path']:
+        all_regexes = '|'.join('(?:%s)' % x for x in args)
+        try:
+            regexp = re.compile(all_regexes)
+        except re.error:
+            sys.exit('ERROR: invalid regular expression')
+
+        matching_pkgs = [x for x in concat([remote_list[x] for x in remote_list]) if regexp.search(x.path) is not None]
+
+        if operation == 'remove-path': # Filter out packages not present in local system
+            matching_pkgs = [x for x in matching_pkgs if pkg_in_map(x, local_list)]
+
+        if len(matching_pkgs) == 0:
+            print 'No matching packages'
+>>>>>>> f7fbc84 (Improved foreign-upgradable/frozen-upgradable to show installed and available versions.)
             sys.exit()
 
         # BCS: easier access to info files for interesting package categories
@@ -2697,12 +2822,14 @@ if __name__ == "__main__":
             current_list = [(x.name, x.version) for x in auto_kernel_pkgs if not superseded_in(x, latest_kernel_pkgs)]
             superseded_list = [(x.name, x.version) for x in auto_kernel_pkgs if superseded_in(x, auto_kernel_pkgs)]
             upgradable_list = [(x.name, x.version) for x in latest_kernel_pkgs if x.name in auto_kernel_pkg_names and x not in auto_kernel_pkgs]
+            keeper_list = [(x.name, x.version) for x in auto_kernel_pkgs if not superseded_in(x, auto_kernel_pkgs) and (x.name, x.version) not in current_list]
             manual_list = [(x.name, x.version) for x in manual_kernel_pkgs]
             available_list = [(x.name, x.version) for x in new_kernel_pkgs]
 
             print_pairs_or(current_list, 'Up-to-date kernel packages:', 'No up-to-date kernel packages')
-            print_pairs_or(upgradable_list, 'Upgradable kernel packages (would be installed by kernel-upgrade):', 'No upgradable kernel packages')
+            print_pairs_or(upgradable_list, 'Newly available versions of kernel packages (would be installed by kernel-upgrade):', 'No upgradable kernel packages')
             print_pairs_or(superseded_list, 'Superseded kernel packages (would be removed by kernel-clean):', 'No superseded kernel packages')
+            print_pairs_or(keeper_list, 'Near-current kernel packages (superseded in repo, but would not be removed by kernel-clean):', 'No superseded kernel packages that would not be removed by kernel-clean')
             print_pairs_or(manual_list, 'Manually managed kernel packages (frozen or foreign):', 'No manually managed kernel packages')
             print_pairs_or(available_list, 'Other available kernel packages:', 'No other kernel packages available for installation or upgrade')
             sys.exit()

--- a/slackroll
+++ b/slackroll
@@ -98,7 +98,7 @@ from packaging import version
 # BCS: Pickle protocols > 2 will not be backward-compatible with Python 2
 pickle_protocol = 2
 
-slackroll_version = 51
+slackroll_version = 53
 
 slackroll_exit_failure = 1
 slackroll_exit_success = 0
@@ -251,6 +251,18 @@ def transient_key(name_state):
     else:
         group = -1
     return (priority, group, name)
+
+# BCS: This function is NO LONGER USED after the conversion to key-style sorting.
+# However, it is required for a test in the current CI pipeline.
+# It can safely be deleted after pull request #22 is merged.
+def transient_cmp(name_state1, name_state2): # Special sort for transient list
+    (name1, state1) = name_state1
+    (name2, state2) = name_state2
+    if name1 in slackroll_prioritized_pkgs or name2 in slackroll_prioritized_pkgs:
+        return pkg_name_cmp(name1, name2)
+    if state1 != state2:
+        return (index_of(slackroll_transient_states, state1) - index_of(slackroll_transient_states, state2))
+    return cmp(name1, name2)
 
 class SlackrollError(Exception):
     pass

--- a/slackroll
+++ b/slackroll
@@ -94,6 +94,7 @@ slackroll_pkg_re_suffix = 6
 
 slackroll_base_dir = os.path.join(os.path.sep, 'var', 'slackroll')
 slackroll_default_temp_dir = os.path.join(slackroll_base_dir, 'tmp')
+slackroll_info_dir = os.path.join(slackroll_base_dir, 'info')
 slackroll_pkgs_dir_glob = os.path.join(slackroll_base_dir, 'packages', '*')
 slackroll_pkgs_dir = os.path.dirname(slackroll_pkgs_dir_glob)
 slackroll_help_file_template = os.path.join(os.path.sep, 'usr', 'doc', 'slackroll-v%s' % slackroll_version, 'helpfiles', '%s.txt')
@@ -1033,12 +1034,15 @@ def download_verify(mirror, package): # Download package, signature and verify i
     try_to_rename(local_name, local_final)
     return local_final
 
-def get_remote_info(mirror, package): # Downloads info file and returns its contents
+def get_remote_info(mirror, package, redownload=False, keep_cached=True): # Downloads info file and returns its contents
+    handle_writable_dir(slackroll_info_dir)
     remote_file = package.fullname[:-len(slackroll_info_suffix)] + slackroll_info_suffix
-    local_file = os.path.join(slackroll_base_dir, os.path.basename(remote_file))
-    download_or_exit(package.base_url(mirror), remote_file, slackroll_base_dir)
+    local_file = os.path.join(slackroll_info_dir, os.path.basename(remote_file))
+    if redownload or not os.path.exists(local_file):
+        download_or_exit(package.base_url(mirror), remote_file, slackroll_info_dir)
     data = io.open(local_file, 'r', encoding="unicode_escape").read()
-    try_to_remove(local_file)
+    if not keep_cached:
+        try_to_remove(local_file)
     return data
 
 def update_changelog(mirror, full=False): # Returns answer to "has it been updated?"
@@ -1936,6 +1940,7 @@ if __name__ == "__main__":
             'download-path':            -1,
             'download-upgrades':        0,
             'erase-cache':              0,
+            'erase-info':               0,
             'erase-tmp':                0,
             'erase-all':                0,
             'foreign':                  -1,
@@ -2120,10 +2125,12 @@ if __name__ == "__main__":
             print_repo_mod_advice()
             sys.exit()
 
-        if operation in ['erase-cache', 'erase-tmp', 'erase-all']:
+        if operation in ['erase-cache', 'erase-info', 'erase-tmp', 'erase-all']:
             directories = []
             if operation in ['erase-cache', 'erase-all']:
                 directories.append(slackroll_pkgs_dir)
+            if operation in ['erase-info', 'erase-all']:
+                directories.append(slackroll_info_dir)
             if operation in ['erase-tmp', 'erase-all']:
                 directories.append(get_temp_dir())
             files = concat([glob.glob(os.path.join(directory, '*')) for directory in directories])

--- a/slackroll
+++ b/slackroll
@@ -1325,7 +1325,7 @@ def print_list(the_list, header): # Print every list entry, sorted
 
 def print_list_or(the_list, header, message_on_empty): # Idem using interceptor and a message if empty list
     if len(the_list) == 0:
-        print message_on_empty
+        print(message_on_empty)
         return
     interceptor = SlackrollOutputInterceptor()
     print_list(the_list, header)
@@ -2902,7 +2902,7 @@ if __name__ == "__main__":
             auto_kernel_pkgs = concat([local_list[x] for x in local_list if x.startswith(slackroll_kernel_pkg_indicator) and (persistent_list[x] == slackroll_state_installed or persistent_list[x] == slackroll_state_outdated)])
             outdated_kernel_pkgs = [x for x in auto_kernel_pkgs if superseded_in(x, auto_kernel_pkgs)]
             if len(outdated_kernel_pkgs) == 0:
-                print 'No obsolete kernel packages found'
+                print('No obsolete kernel packages found')
                 sys.exit()
             print_pairs_or([(x.name, x.version + '-' + x.build) for x in outdated_kernel_pkgs], 'Superseded kernel packages to be removed:', 'No superseded kernel packages to remove')
             if "kernel-source" in [x.name for x in outdated_kernel_pkgs]:

--- a/slackroll
+++ b/slackroll
@@ -27,8 +27,8 @@ from builtins import object
 from builtins import range
 from builtins import str
 
-import io
 import sys
+import io
 
 PY2 = sys.version_info[0] <= 2
 
@@ -40,18 +40,22 @@ if PY2:
 else:
     import dbm
 
-# Workaround for Unicode/bytestring handling differences between Python 2 and 3
+# Prefer to write files in UTF-8 for easiest interoperability between Python 2 and 3
 default_output_encoding = "UTF-8"
+
+# Slackware ChangeLog and package info files are normally in the Latin charset
+assumed_file_encoding = "latin-1"
+
+# Set up stdout to accommodate Unicode/bytestring handling differences between Python 2 and 3
 if PY2:
     def print(message=""):
-        write_to_pipe(sys.stdout, message + "\n")
+        write_to_stream(sys.stdout, message + "\n")
     import collections
 else:
     sys.stdout = io.open(sys.stdout.fileno(), mode='w', encoding=default_output_encoding, buffering=1)
 
 import bz2
 import pickle
-import io
 import fcntl
 import functools
 import glob
@@ -427,19 +431,26 @@ def to_dbkey(x):
     return x.encode(default_output_encoding)
 
 # Attempt to determine/use the system-set encoding for the given file or pipe
-def output_encoding(stream):
+def stream_encoding(stream, fallback_if_not_determined):
     try:
         if stream.encoding is None:
-            return default_output_encoding
+            return fallback_if_not_determined
         else:
             return stream.encoding
     except (AttributeError, TypeError):
         pass
-    return default_output_encoding
+    return fallback_if_not_determined
+
+def output_encoding(stream):
+    return stream_encoding(stream, default_output_encoding)
+
+# Assume that ChangeLogs, package info files, etc. are more likely be be in latin-1
+def input_encoding(stream):
+    return stream_encoding(stream, assumed_file_encoding)
 
 # Consolidate writes in one place to handle string/representation conversions between Python 2 & 3
 # Use force_encoding when the source of the text was itself a pipe (e.g. pager program)
-def write_to_pipe(fd, text, force_encoding=False):
+def write_to_stream(fd, text, force_encoding=False):
     preferred_encoding = output_encoding(fd)
     if PY2:
         # Provide some backup options in case the detected encoding is limited (e.g. pager stdin pipe will probably report 'ascii')
@@ -450,10 +461,7 @@ def write_to_pipe(fd, text, force_encoding=False):
         while len(trial_encodings) > 0: 
             encoding = trial_encodings.popleft()
             try:
-                if force_encoding:
-                    fd.write(text.encode(encoding))
-                else:
-                    fd.write(text.decode(encoding))
+                fd.write(text.encode(encoding))
                 return
             except UnicodeEncodeError:
                 if len(trial_encodings) > 0:
@@ -465,8 +473,36 @@ def write_to_pipe(fd, text, force_encoding=False):
     else:
         fd.write(text)
 
+# Consolidate reads in one place to handle string/representation conversions between Python 2 & 3
+def read_stream(fd): # Read entire stream into single internal buffer
+    if PY2 and False:
+        inferred_encoding = input_encoding(fd)
+        return fd.read().encode(inferred_encoding)
+    else:
+        return fd.read()
+
+def read_lines_from_stream(fd): # Read text stream into a list of individual lines
+    if PY2:
+        inferred_encoding = input_encoding(fd)
+        raw = fd.readlines()
+        return [x.encode(inferred_encoding) for x in raw]
+    else:
+        return fd.readlines()
+
+def read_file(filename): # Wrapper to open file in appropriate encoding mode
+    if PY2:
+        return read_stream(io.open(filename, 'r', encoding=assumed_file_encoding))
+    else:
+        return read_stream(io.open(filename, 'r'))
+
+def read_lines_from_file(filename): # Wrapper to open file in appropriate encoding mode
+    if PY2:
+        return read_lines_from_stream(io.open(filename, 'r', encoding=assumed_file_encoding))
+    else:
+        return read_lines_from_stream(io.open(filename, 'r'))
+
 def print_flush(message=""):
-    write_to_pipe(sys.stdout, message)
+    write_to_stream(sys.stdout, message)
     sys.stdout.flush()
 
 def concat(list_of_lists):
@@ -625,7 +661,7 @@ def clean_filename(s, encoding="latin1"):
 
 def extract_file_list(filename): # Extracts the file list from a local info file
     try:
-        lines = io.open(filename, 'r', encoding="unicode_escape").readlines()
+        lines = read_lines_from_file(filename)
         paths = ['/%s' % clean_filename(x) for x in lines[lines.index(slackroll_local_pkg_filelist_marker) + 1:]]
         return paths
     except ValueError:
@@ -688,7 +724,7 @@ def get_local_list(forced_rebuild): # Return list of local packages from cached 
 
 def get_remote_pkgs(local_filelist, url): # Return a list of packages from FILELIST.TXT
     try:
-        lines = io.open(local_filelist, 'r', encoding="unicode_escape").readlines()
+        lines = read_lines_from_file(local_filelist)
         matches = [slackroll_filelist_pkg_re.match(x) for x in lines]
         nm_sz = [(x.group(slackroll_filelist_pkg_str), x.group(slackroll_filelist_pkg_size)) for x in matches if x is not None]
         return [pkg_from_name_size_url(nm, sz, url) for (nm, sz) in nm_sz if slackroll_source_indicator not in nm]
@@ -725,7 +761,7 @@ def get_remote_list(): # Return list of remote packages from cached list, updati
 def get_mirror_from_file(filepath):
     try:
         filename = os.path.basename(filepath)
-        lines = io.open(filepath, 'r', encoding="unicode_escape").readlines()
+        lines = read_lines_from_file(filepath)
         if len(lines) != 1:
             raise ValueError('more than one line on %s file' % filename)
         mirror = lines[0].strip()
@@ -845,17 +881,17 @@ class SlackrollOutputInterceptor(object): # Intercepts stdout and uses a pager i
         numlines = output.count('\n')
         if needs_pager(numlines):
             proc = call_pager()
-            write_to_pipe(proc.stdin, output, True)
+            write_to_stream(proc.stdin, output, True)
             proc.stdin.close()
             proc.wait()
         else:
-            write_to_pipe(sys.stdout, output)
+            write_to_stream(sys.stdout, output)
 
 def run_program(arg_list, env=None): # Does not exit on errors
     try:
         subprocess.call(arg_list, env=env)
     except (OSError, IOError) as err:
-        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
+        write_to_stream(sys.stderr, 'ERROR: %s\n' % err)
 
 def run_visual_on(file_path): # Does not exit on errors
     run_program(get_visual().split() + [file_path])
@@ -870,7 +906,7 @@ def try_to_remove(file_path, fatal=True): # When it returns, it is True if file 
         os.remove(file_path)
         return True
     except (OSError, IOError) as err:
-        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
+        write_to_stream(sys.stderr, 'ERROR: %s\n' % err)
         if fatal:
             sys.exit(slackroll_exit_failure)
         return False
@@ -880,7 +916,7 @@ def try_to_rename(src, dest, fatal=True): # When it returns, it is True if file 
         os.rename(src, dest)
         return True
     except (OSError, IOError) as err:
-        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
+        write_to_stream(sys.stderr, 'ERROR: %s\n' % err)
         if fatal:
             sys.exit(slackroll_exit_failure)
         return False
@@ -906,7 +942,7 @@ def download_file(mirror, filepath, local_temp, local_final, displayed_name=None
         if not try_to_rename(local_temp, local_final, fatal=False):
             raise SlackrollError('rename error: %s => %s' % (local_temp, local_final))
     except (OSError, IOError, socket.error, urllib.error.ContentTooShortError) as err:
-        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
+        write_to_stream(sys.stderr, 'ERROR: %s\n' % err)
         raise SlackrollError(str(err))
 
 def download(mirror, filepath, localdir, displayed_name=None): # Wrapper that does NOT exit on errors
@@ -960,10 +996,10 @@ def verify_signature(filename):    # Does not exit on errors
         print('Verifying signature %s ... ' % os.path.basename(filename))
         retcode = subprocess.call([gnupg_exec_name, '--verify', filename], stdout=open(os.path.devnull, 'w'), stderr=subprocess.STDOUT)
         if retcode != 0:
-            write_to_pipe(sys.stderr, 'ERROR: signature verification failed: %s\n' % filename)
+            write_to_stream(sys.stderr, 'ERROR: signature verification failed: %s\n' % filename)
             raise SlackrollError('GnuPG exited with status code %s' % retcode)
     except (OSError, IOError) as err:
-        write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
+        write_to_stream(sys.stderr, 'ERROR: %s\n' % err)
         raise SlackrollError(str(err))
 
 def upgrade_or_install(filename, reinstall): # upgradepkg
@@ -1040,7 +1076,7 @@ def get_remote_info(mirror, package, redownload=False, keep_cached=True): # Down
     local_file = os.path.join(slackroll_info_dir, os.path.basename(remote_file))
     if redownload or not os.path.exists(local_file):
         download_or_exit(package.base_url(mirror), remote_file, slackroll_info_dir)
-    data = io.open(local_file, 'r', encoding="unicode_escape").read()
+    data = read_file(local_file)
     if not keep_cached:
         try_to_remove(local_file)
     return data
@@ -1050,7 +1086,7 @@ def update_changelog(mirror, full=False): # Returns answer to "has it been updat
         temp_dir = get_temp_dir()
         download_or_exit(mirror, slackroll_changelog_filename, temp_dir)
         local_filename = os.path.join(temp_dir, slackroll_changelog_filename)
-        text = io.open(local_filename, 'r', encoding="unicode_escape").read()
+        text = read_file(local_filename)
         cl = ChangeLog()
         cl.add_entries(clentrylist_from_text(text))
         try_dump(cl, slackroll_local_changelog)
@@ -1259,9 +1295,9 @@ def tr_pkg_detail(local_list, remote_list, persistent_list, pkg_name): # Returns
     return ' '.join(x.path for x in remote_list[pkg_name])
 
 def error_unknown_packages(name_list): # Print package names as unknown and exit with error
-    write_to_pipe(sys.stderr, ''.join('WARNING: %s looks like an unexpected full version\n' % x for x in name_list if may_be_full_version(x)))
-    write_to_pipe(sys.stderr, 'ERROR: The following packages are unknown:\n')
-    write_to_pipe(sys.stderr, ''.join('ERROR:    %s\n' % x for x in name_list))
+    write_to_stream(sys.stderr, ''.join('WARNING: %s looks like an unexpected full version\n' % x for x in name_list if may_be_full_version(x)))
+    write_to_stream(sys.stderr, 'ERROR: The following packages are unknown:\n')
+    write_to_stream(sys.stderr, ''.join('ERROR:    %s\n' % x for x in name_list))
     sys.exit(slackroll_exit_failure)
 
 def maybe_error_unknown_packages(name_list, by_name):
@@ -1310,7 +1346,7 @@ def handle_dotnew_files_installation_batch(dotnew_files): # Handles .new files p
             new_exists = os.path.exists(newfile)
             old_exists = os.path.exists(oldfile)
         except (OSError, IOError) as err:
-            write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
+            write_to_stream(sys.stderr, 'ERROR: %s\n' % err)
             break
 
         if new_exists and old_exists: # Both
@@ -1349,7 +1385,7 @@ def handle_dotnew_files_installation_interactive(dotnew_files): # Handles .new f
                 new_exists = os.path.exists(newfile)
                 old_exists = os.path.exists(oldfile)
             except (OSError, IOError) as err:
-                write_to_pipe(sys.stderr, 'ERROR: %s\n' % err)
+                write_to_stream(sys.stderr, 'ERROR: %s\n' % err)
                 break
 
             print('\n%s %s' % (['Reviewing', 'Still reviewing'][pair_iterations > 1], newfile))
@@ -1668,7 +1704,7 @@ def install_operations_family(operation, args, local_list, remote_list, persiste
         for pkg in chosen_pkgs:
             try:
                 if pkg_in_map(pkg, local_list):
-                    lines = io.open(pkg.fullname, 'r', encoding="unicode_escape").readlines()
+                    lines = read_lines_from_file(pkg.fullname)
                     header = lines[:lines.index(slackroll_local_pkg_filelist_marker)]
                     info_map[pkg.fullname] = ''.join(header)
                 else:
@@ -1691,7 +1727,7 @@ def install_operations_family(operation, args, local_list, remote_list, persiste
 def extend_manifest_list(manifest_list, index, mirror, local_filelist):
     # Build the list of MANIFEST.bz2 files
     try:
-        lines = io.open(local_filelist, 'r', encoding="unicode_escape").readlines()
+        lines = read_lines_from_file(local_filelist)
     except (IOError, OSError) as err:
         sys.exit('ERROR: %s' % err)
     files = [slackroll_manifest_re.search(x) for x in lines]
@@ -1822,9 +1858,9 @@ def verify_operation_and_args(op_num_args, operation, args): # Verify number of 
         best_matches.sort()
 
         # Print the error and the list.
-        write_to_pipe(sys.stderr, 'ERROR: no operation called "%s"\n' % (operation, ))
-        write_to_pipe(sys.stderr, 'Use the "help" operation to get a list.\n')
-        write_to_pipe(sys.stderr, 'Did you mean %s?\n' % ' or '.join('"%s"' % ('-'.join(x), ) for x in best_matches))
+        write_to_stream(sys.stderr, 'ERROR: no operation called "%s"\n' % (operation, ))
+        write_to_stream(sys.stderr, 'Use the "help" operation to get a list.\n')
+        write_to_stream(sys.stderr, 'Did you mean %s?\n' % ' or '.join('"%s"' % ('-'.join(x), ) for x in best_matches))
         sys.exit(slackroll_exit_failure)
     else:
         verify_num_args(op_num_args[operation], operation, args)
@@ -2046,7 +2082,7 @@ if __name__ == "__main__":
             if not is_readable_file(helpfile):
                 sys.exit('ERROR: no help found for "%s"' % helpname)
             interceptor = SlackrollOutputInterceptor()
-            print(io.open(helpfile, 'r', encoding="unicode_escape").read())
+            print(read_file(helpfile))
             interceptor.stop()
             sys.exit()
 
@@ -2657,7 +2693,8 @@ if __name__ == "__main__":
             verify_local_names(args, local_list)
             interceptor = SlackrollOutputInterceptor()
             try:
-                print('\n'.join(io.open(x.fullname, 'r', encoding="unicode_escape").read() for x in concat(local_list[pkg] for pkg in args)))
+                print('\n'.join(read_file(x.filename) for x in concat(local_list[pkg] for pkg in args)))
+
             except (IOError, OSError) as err:
                 sys.exit('ERROR: %s' % err)
             interceptor.stop()
@@ -2667,8 +2704,8 @@ if __name__ == "__main__":
             # Verify readable files
             bad_files = [x for x in args if not is_readable_file(x)]
             if len(bad_files) > 0:
-                write_to_pipe(sys.stderr, 'ERROR: the following items are not readable files:\n')
-                write_to_pipe(sys.stderr, ''.join('ERROR:    %s\n' % x for x in bad_files))
+                write_to_stream(sys.stderr, 'ERROR: the following items are not readable files:\n')
+                write_to_stream(sys.stderr, ''.join('ERROR:    %s\n' % x for x in bad_files))
                 sys.exit(slackroll_exit_failure)
 
             # Verify and get package names
@@ -2680,8 +2717,8 @@ if __name__ == "__main__":
             # The packages must not be present in persistent list or be foreign already
             bad_pkgs = [x for x in pkgs if to_dbkey(x.name) in persistent_list and persistent_list[x.name] != slackroll_state_foreign]
             if len(bad_pkgs) > 0:
-                write_to_pipe(sys.stderr, 'ERROR: the following packages are known and not foreign\n')
-                write_to_pipe(sys.stderr, ''.join('ERROR:    %s\n' % x.name for x in bad_pkgs))
+                write_to_stream(sys.stderr, 'ERROR: the following packages are known and not foreign\n')
+                write_to_stream(sys.stderr, ''.join('ERROR:    %s\n' % x.name for x in bad_pkgs))
                 sys.exit(slackroll_exit_failure)
 
             # Get .new files from old packages
@@ -2707,7 +2744,7 @@ if __name__ == "__main__":
             for name in args:
                 if name not in persistent_list:
                     if may_be_full_version(name):
-                        write_to_pipe(sys.stderr, 'WARNING: %s looks like an unexpected full version\n' % name)
+                        write_to_stream(sys.stderr, 'WARNING: %s looks like an unexpected full version\n' % name)
                     sys.exit('ERROR: no package named %s' % name)
 
             unavpkg = args[0]
@@ -2837,16 +2874,16 @@ if __name__ == "__main__":
 
     except (KeyboardInterrupt, IOError, EOFError) as error:
         if isinstance(error, KeyboardInterrupt):
-            write_to_pipe(sys.stderr, '\nProgram aborted by user\n')
+            write_to_stream(sys.stderr, '\nProgram aborted by user\n')
         if persistent_list is not None:
             persistent_list.close()
         sys.exit(slackroll_exit_failure)
     except SlackrollBatchModeError:
-        write_to_pipe(sys.stderr, '\nProgram aborted because operation could not be completed in batch mode\n')
+        write_to_stream(sys.stderr, '\nProgram aborted because operation could not be completed in batch mode\n')
         if persistent_list is not None:
             persistent_list.close()
         sys.exit(slackroll_exit_failure)
     except IndexError:
-        write_to_pipe(sys.stderr, 'ERROR: no operation given\n')
-        write_to_pipe(sys.stderr, 'Use "help" operation to get a list\n')
+        write_to_stream(sys.stderr, 'ERROR: no operation given\n')
+        write_to_stream(sys.stderr, 'Use "help" operation to get a list\n')
         sys.exit(slackroll_exit_failure)

--- a/slackroll
+++ b/slackroll
@@ -874,7 +874,7 @@ gnupg_exec_name = next(yield_gnupg_exec_name())
 def import_key(filename):
     try:
         print('Importing keys from %s ...' % filename)
-        retcode = subprocess.call([gnupg_exec_name(), '--import', filename], stdout=open(os.path.devnull, 'w'), stderr=subprocess.STDOUT)
+        retcode = subprocess.call([gnupg_exec_name, '--import', filename], stdout=open(os.path.devnull, 'w'), stderr=subprocess.STDOUT)
         if retcode != 0:
             raise SlackrollError('GnuPG exited with error when importing key')
     except (OSError, IOError, SlackrollError) as err:
@@ -883,7 +883,7 @@ def import_key(filename):
 def verify_signature(filename):    # Does not exit on errors
     try:
         print('Verifying signature %s ... ' % os.path.basename(filename))
-        retcode = subprocess.call([gnupg_exec_name(), '--verify', filename], stdout=open(os.path.devnull, 'w'), stderr=subprocess.STDOUT)
+        retcode = subprocess.call([gnupg_exec_name, '--verify', filename], stdout=open(os.path.devnull, 'w'), stderr=subprocess.STDOUT)
         if retcode != 0:
             sys.stderr.write('ERROR: signature verification failed: %s\n' % filename)
             raise SlackrollError('GnuPG exited with status code %s' % retcode)

--- a/slackroll
+++ b/slackroll
@@ -355,10 +355,6 @@ class SlackwarePackage(object):
     def sig_url(self, mirror):
         return urllib.parse.urljoin(self.base_url(mirror), str(self.fullsigname))
 
-class SlackrollURLopener(urllib.request.FancyURLopener):
-    def http_error_default(self, url, fp, errcode, errmsg, headers):
-        raise IOError('%s: %s' % (errcode, errmsg))
-
 def pkg_from_str(path_or_name): # Create a SlackwarePackage object from a string
     return pkg_from_name_size_url(path_or_name)
 
@@ -2023,7 +2019,6 @@ if __name__ == "__main__":
         local_list = None
         remote_list = None
         persistent_list = None
-        urllib._urlopener = SlackrollURLopener()
         socket.setdefaulttimeout(slackroll_socket_timeout)
         standardize_locales()
 

--- a/slackroll
+++ b/slackroll
@@ -30,6 +30,8 @@ from builtins import str
 import sys
 import io
 
+debug_output = True
+
 PY2 = sys.version_info[0] <= 2
 
 if PY2:
@@ -58,10 +60,11 @@ else:
 
 # Safe whether stdout is a Unicode or binary stream, under Python 2 or 3
 def print(message=""):
-    if isinstance(sys.stdout, io.BytesIO) and not is_encoded(message):
-        message = message.encode(default_output_encoding, "replace")
+    if isinstance(sys.stdout, io.BytesIO):
+        if not is_encoded(message):
+            message = message.encode(default_output_encoding, "replace")
         write_to_stream(sys.stdout, message + b"\n")
-    elif isinstance(message, bytes):
+    elif not PY2 and isinstance(message, bytes):
         write_to_stream(sys.stdout, message + b"\n")
     else:
         write_to_stream(sys.stdout, message + "\n")
@@ -191,7 +194,7 @@ slackroll_manifest_list_filename = os.path.join(slackroll_base_dir, 'manifestlis
 slackroll_batch_mode = False
 
 def debug_mesg(mesg):
-    if True:
+    if debug_output:
         sys.stderr.write(mesg)
     else:
         return
@@ -460,8 +463,6 @@ def format_for_writing(text, always_encode=False, encoding = default_output_enco
 def force_to_unicode(text):
     if not is_encoded(text):
         return text
-    elif PY2:
-        return unicode(text)
     else:
         return try_encodings(text.decode, standard_encodings)
 

--- a/slackroll
+++ b/slackroll
@@ -1160,13 +1160,13 @@ def print_list_or(the_list, header, message_on_empty): # Idem using interceptor 
 # BCS: useful for printing version numbers within some commands, e.g. maintaining kernel packages
 def print_pairs_or(the_list, header, message_on_empty):
     if len(the_list) == 0:
-        print message_on_empty
+        print(message_on_empty)
         return
     interceptor = SlackrollOutputInterceptor()
-    print header
+    print(header)
     the_list.sort()
     for (a, b) in the_list:
-        print ' %s (%s)' % (a, b)
+        print(' %s (%s)' % (a, b))
     interceptor.stop()
 
 def superseded_in(pkg, the_list):
@@ -2429,7 +2429,7 @@ if __name__ == "__main__":
             names = pkgs_in_state(persistent_list, states)
             names.sort(cmp=pkg_name_cmp)
             if len(names) == 0:
-                print 'No %s packages' % state_str
+                print('No %s packages' % state_str)
             else:
                 install_operations_family('info', names, local_list, remote_list, persistent_list)
                 sys.exit()
@@ -2724,7 +2724,7 @@ if __name__ == "__main__":
                 sys.exit()
             print_pairs_or([(x.name, x.version + '-' + x.build) for x in outdated_kernel_pkgs], 'Superseded kernel packages to be removed:', 'No superseded kernel packages to remove')
             if "kernel-source" in [x.name for x in outdated_kernel_pkgs]:
-                print "You may wish to run a 'make clean' or 'make distclean' in kernel source directories before removing the package"
+                print("You may wish to run a 'make clean' or 'make distclean' in kernel source directories before removing the package")
             maybe_confirm_continue()
             remove_pkgs(outdated_kernel_pkgs)
             post_kernel_operation()

--- a/slackroll
+++ b/slackroll
@@ -40,19 +40,31 @@ if PY2:
 else:
     import dbm
 
-# Prefer to write files in UTF-8 for easiest interoperability between Python 2 and 3
-default_output_encoding = "UTF-8"
+# Slackware ChangeLog and package info files are normally in the Windows charset (1252 / ANSI), supported by most terminals
+# Note 2 March 2022 ChangeLog entry contains a character (0x9E) /not/ in the ASCII or Latin-1 (8859-1) character sets
+# Recommend keeping filenames in Latin-1 for maximum interoperability
+assumed_file_encoding = "CP1252"
+default_output_encoding = "CP1252"
+default_filename_encoding = "Latin-1"
+standard_encodings = ["CP1252", "Latin-1", "UTF-8", "unicode_internal"]
 
-# Slackware ChangeLog and package info files are normally in the Latin charset
-assumed_file_encoding = "latin-1"
-
-# Set up stdout to accommodate Unicode/bytestring handling differences between Python 2 and 3
+# Accommodate Unicode/bytestring handling differences between Python 2 and 3
 if PY2:
-    def print(message=""):
-        write_to_stream(sys.stdout, message + "\n")
+    interceptor_newline = '\n'
     import collections
 else:
-    sys.stdout = io.open(sys.stdout.fileno(), mode='w', encoding=default_output_encoding, buffering=1)
+    sys.stdout = io.open(sys.stdout.fileno(), mode='wb')
+    interceptor_newline = b'\n'
+
+# Safe whether stdout is a Unicode or binary stream, under Python 2 or 3
+def print(message=""):
+    if isinstance(sys.stdout, io.BytesIO) and not is_encoded(message):
+        message = message.encode(default_output_encoding, "replace")
+        write_to_stream(sys.stdout, message + b"\n")
+    elif isinstance(message, bytes):
+        write_to_stream(sys.stdout, message + b"\n")
+    else:
+        write_to_stream(sys.stdout, message + "\n")
 
 import bz2
 import pickle
@@ -177,6 +189,12 @@ slackroll_manifest_basename = 'MANIFEST.bz2'
 slackroll_manifest_filename = os.path.join(slackroll_base_dir, 'manifest.db')
 slackroll_manifest_list_filename = os.path.join(slackroll_base_dir, 'manifestlist.db')
 slackroll_batch_mode = False
+
+def debug_mesg(mesg):
+    if True:
+        sys.stderr.write(mesg)
+    else:
+        return
 
 def yield_slackroll_local_pkgs_dir():
     for opt in slackroll_local_pkgs_dir_names:
@@ -329,10 +347,10 @@ class SlackwarePackage(object):
         return self.__base_url
 
     def url(self, mirror):
-        return urllib.parse.urljoin(self.base_url(mirror), self.fullname)
+        return urllib.parse.urljoin(self.base_url(mirror), interpret_as_str(self.fullname))
 
     def sig_url(self, mirror):
-        return urllib.parse.urljoin(self.base_url(mirror), self.fullsigname)
+        return urllib.parse.urljoin(self.base_url(mirror), str(self.fullsigname))
 
 class SlackrollURLopener(urllib.request.FancyURLopener):
     def http_error_default(self, url, fp, errcode, errmsg, headers):
@@ -424,11 +442,43 @@ def clentrylist_from_text(text):
     entries = [x for x in entries if len(x) > 0]
     return [clentry_from_text(x) for x in entries]
 
-# dbm on Python 2 only accepts encoded strings as keys, not general Unicode
+# True iff the argument is already encoded to an output representation (not abstract Unicode)
+def is_encoded(text):
+    if PY2:
+        return not isinstance(text, unicode)
+    else:
+        return isinstance(text, bytes)
+
+# Convert the argument into a format that a binary stream .write() method will accept (str for Python 2, bytes for Python 3)
+def format_for_writing(text, always_encode=False, encoding = default_output_encoding, mode="strict"):
+    if (always_encode and PY2) or not is_encoded(text):
+        return text.encode(encoding, mode)
+    else:
+        return text
+
+# Convert the argument into a format that a Unicode stream .write() method will accept (unicode for Python 2, str for Python 3)
+def force_to_unicode(text):
+    if not is_encoded(text):
+        return text
+    elif PY2:
+        return unicode(text)
+    else:
+        return try_encodings(text.decode, standard_encodings)
+
+# Coerce the argument into the default internal "string" format if not already
+# Differs from system str() in that this attempts each the specified encodings until one succeeds
+# User beware: on Python 2 this is a bytestring, on Python 3 it will be abstract Unicode
+def interpret_as_str(text, encodings = standard_encodings):
+    if PY2 and isinstance(text, unicode):
+        return try_encodings(text.encode, encodings)
+    elif not PY2 and not isinstance(text, str):
+        return try_encodings(text.decode, encodings)
+    else:
+        return text
+
+# dbm on Python 2 only accepts decoded strings as keys, not general Unicode
 def to_dbkey(x):
-    if isinstance(x, str):
-        return x
-    return x.encode(default_output_encoding)
+    return interpret_as_str(x)
 
 # Attempt to determine/use the system-set encoding for the given file or pipe
 def stream_encoding(stream, fallback_if_not_determined):
@@ -441,65 +491,68 @@ def stream_encoding(stream, fallback_if_not_determined):
         pass
     return fallback_if_not_determined
 
-def output_encoding(stream):
+def output_encoding(stream):  # Determine most appropriate encoding for output stream
     return stream_encoding(stream, default_output_encoding)
 
-# Assume that ChangeLogs, package info files, etc. are more likely be be in latin-1
-def input_encoding(stream):
+def input_encoding(stream):   # Guess most likely encoding for input stream
     return stream_encoding(stream, assumed_file_encoding)
+
+# Helper function to construct a list with no duplicates
+def merge_encodings(preferred, defaults):
+    rv = [preferred]
+    for x in defaults:
+        rv.append(x)
+    return rv
+
+# Monad to repeat a Unicode-related operation until a successful encoding/decoding is found
+def try_encodings(operation, encodings):
+    for trial_encoding in encodings:
+        try:
+            return operation(trial_encoding, "strict")
+        except (UnicodeEncodeError, UnicodeDecodeError, TypeError) as err:
+            pass
+
+    # Retry last-resort encoding with character replacement
+    return operation(trial_encoding, "replace")
+
 
 # Consolidate writes in one place to handle string/representation conversions between Python 2 & 3
 # Use force_encoding when the source of the text was itself a pipe (e.g. pager program)
 def write_to_stream(fd, text, force_encoding=False):
-    preferred_encoding = output_encoding(fd)
-    if PY2:
-        # Provide some backup options in case the detected encoding is limited (e.g. pager stdin pipe will probably report 'ascii')
-        trial_encodings = collections.deque()
-        for i in [preferred_encoding, "latin_1", "UTF-8", "unicode_internal"]:
-            if i not in trial_encodings:
-                trial_encodings.append(i)
-        while len(trial_encodings) > 0: 
-            encoding = trial_encodings.popleft()
-            try:
-                fd.write(text.encode(encoding))
-                return
-            except UnicodeEncodeError:
-                if len(trial_encodings) > 0:
-                    continue
-                else:
-                    raise
-    elif force_encoding:
-        fd.write(text.encode(preferred_encoding))
-    else:
-        fd.write(text)
+    try:
+        # Easiest case, assuming the text encodes in the default stream format
+        fd.write(format_for_writing(text, force_encoding))
+        return
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        pass
+    except (TypeError) as err:
+        # Most likely an output stream (e.g. Interceptor) opened for Unicode only
+        fd.write(force_to_unicode(text))
+        return
+
+    # OK, try reasonable encodings until we find one that can handle this buffer
+    potential_encodings = merge_encodings(output_encoding(fd), standard_encodings)
+    writer = lambda trial_encoding, mode : fd.write(format_for_writing(text, True, trial_encoding, mode))
+    try_encodings(writer, potential_encodings)
+    return
 
 # Consolidate reads in one place to handle string/representation conversions between Python 2 & 3
 def read_stream(fd): # Read entire stream into single internal buffer
-    if PY2 and False:
-        inferred_encoding = input_encoding(fd)
-        return fd.read().encode(inferred_encoding)
-    else:
-        return fd.read()
+    potential_encodings = merge_encodings(input_encoding(fd), standard_encodings)
+    raw_text = fd.read()
+    return interpret_as_str(raw_text, potential_encodings)
 
 def read_lines_from_stream(fd): # Read text stream into a list of individual lines
-    if PY2:
-        inferred_encoding = input_encoding(fd)
-        raw = fd.readlines()
-        return [x.encode(inferred_encoding) for x in raw]
-    else:
-        return fd.readlines()
+    potential_encodings = merge_encodings(input_encoding(fd), standard_encodings)
+    raw_text = fd.readlines()
+    decoder = lambda trial_encoding, mode : [x.decode(trial_encoding, mode) for x in raw_text]
+    return try_encodings(decoder, potential_encodings)
 
 def read_file(filename): # Wrapper to open file in appropriate encoding mode
-    if PY2:
-        return read_stream(io.open(filename, 'r', encoding=assumed_file_encoding))
-    else:
-        return read_stream(io.open(filename, 'r'))
+    return read_stream(io.open(filename, 'rb'))
 
 def read_lines_from_file(filename): # Wrapper to open file in appropriate encoding mode
-    if PY2:
-        return read_lines_from_stream(io.open(filename, 'r', encoding=assumed_file_encoding))
-    else:
-        return read_lines_from_stream(io.open(filename, 'r'))
+    return read_lines_from_stream(io.open(filename, 'rb'))
 
 def print_flush(message=""):
     write_to_stream(sys.stdout, message)
@@ -650,14 +703,15 @@ def print_blacklist():
     numbered = ['%-4s  %s' % (x, bl[x]) for x in range(len(bl))]
     print_list_or(numbered, 'Blacklisted expressions:', 'No blacklisted expressions')
 
-def clean_filename(s, encoding="latin1"):
+def clean_filename(s, encoding=default_filename_encoding):
     if PY2:
         return s.strip().decode('string_escape')
     else:
-        if encoding == "latin1":
+        if encoding == default_filename_encoding:
             return s.strip().encode(encoding).decode("unicode_escape")
         else:
-            return s.strip().encode(encoding).decode("unicode_escape").encode("latin1").decode(encoding)
+            # Horrendous but robust
+            return s.strip().encode(encoding).decode("unicode_escape").encode(default_filename_encoding).decode(encoding)
 
 def extract_file_list(filename): # Extracts the file list from a local info file
     try:
@@ -710,7 +764,7 @@ def get_local_list(forced_rebuild): # Return list of local packages from cached 
         dupes = set()
         local_list = dict()
         for pkg in get_local_pkgs():
-            name = pkg.name
+            name = to_dbkey(pkg.name)
             if name in local_list:
                 dupes.add(name)
             value = local_list.get(name, [])
@@ -867,7 +921,11 @@ class SlackrollOutputInterceptor(object): # Intercepts stdout and uses a pager i
         if not sys.stdout.isatty():
             self.__was_not_tty = True
             return
-        self.__buffer = io.StringIO()
+        self.__was_not_tty = False
+        if PY2:
+            self.__buffer = io.StringIO()
+        else:
+            self.__buffer = io.BytesIO()
         self.__old_stdout = sys.stdout
         sys.stdout = self.__buffer
 
@@ -878,7 +936,7 @@ class SlackrollOutputInterceptor(object): # Intercepts stdout and uses a pager i
         self.__old_stdout = None
         output = self.__buffer.getvalue()
         self.__buffer.close()
-        numlines = output.count('\n')
+        numlines = output.count(interceptor_newline)
         if needs_pager(numlines):
             proc = call_pager()
             write_to_stream(proc.stdin, output, True)
@@ -1101,7 +1159,7 @@ def update_changelog(mirror, full=False): # Returns answer to "has it been updat
     except (OSError, IOError) as err:
         sys.exit('ERROR: %s' % err)
 
-    changelog_url = urllib.parse.urljoin(mirror, slackroll_changelog_filename)
+    changelog_url = urllib.parse.urljoin(str(mirror), str(slackroll_changelog_filename))
     lines = []
     try:
         conn = urllib.request.urlopen(changelog_url)
@@ -1109,7 +1167,7 @@ def update_changelog(mirror, full=False): # Returns answer to "has it been updat
             new_line = conn.readline()
             if len(new_line) == 0 or new_line.strip() in limits:
                 break
-            lines.append(new_line)
+            lines.append(interpret_as_str(new_line))
         conn.close()
     except (OSError, IOError, socket.error, urllib.error.ContentTooShortError) as err:
         sys.exit('\nERROR: %s' % err)
@@ -1210,7 +1268,8 @@ def print_repo_mod_advice():
 def maybe_confirm_continue():
     if slackroll_batch_mode:
         return
-    input('Press Ctrl+C to cancel or Enter to continue... ')
+    print('Press Ctrl+C to cancel or Enter to continue... ')
+    input()
 
 def print_in_states(states, persistent_list, header, print_state): # Print package name if its state matches
     keys = pkgs_in_state(persistent_list, states)
@@ -1749,7 +1808,7 @@ def update_operation(mirror):
 
     for (x, repo) in enumerate(get_repo_list()):
         displayed_name = '%s from repository %s' % (slackroll_filelist_filename, x)
-        full_url = urllib.parse.urljoin(repo, slackroll_filelist_filename)
+        full_url = urllib.parse.urljoin(str(repo), str(slackroll_filelist_filename))
         download_or_exit(repo, slackroll_filelist_filename, get_temp_dir(), displayed_name)
         extend_remote_list(local_filelist, remote_list, repo)
         extend_manifest_list(manifest_list, x, repo, local_filelist)
@@ -1790,7 +1849,8 @@ def analyze_changes(local_list, remote_list, persistent_list): # XXX THIS FUNCTI
     already_analyzed = set()
 
     # Go over packages present in local system and update their state or introduce them
-    for name in local_list:
+    for raw_name in local_list:
+        name = to_dbkey(raw_name)
         already_analyzed.add(name)
         if name in persistent_list:
             # Update their state if needed
@@ -1820,7 +1880,8 @@ def analyze_changes(local_list, remote_list, persistent_list): # XXX THIS FUNCTI
                 persistent_list[name] = slackroll_state_unavailable
 
     # Go over remaining remote packages not already analyzed (hence, not present in local system)
-    for name in remote_list:
+    for raw_name in remote_list:
+        name = to_dbkey(raw_name)
         if name in already_analyzed:
             continue
         already_analyzed.add(name)
@@ -1839,7 +1900,8 @@ def analyze_changes(local_list, remote_list, persistent_list): # XXX THIS FUNCTI
                 persistent_list[name] = slackroll_state_new
 
     # Remaining packages, not present in local or remote systems, need to disappear
-    for name in list(persistent_list.keys()):    # Must get keys before, as we are going to delete entries
+    for raw_name in list(persistent_list.keys()):    # Must get keys before, as we are going to delete entries
+        name = to_dbkey(raw_name)
         if name in already_analyzed:
             continue
         del persistent_list[name]

--- a/slackroll
+++ b/slackroll
@@ -1358,7 +1358,7 @@ def print_pairs_or(the_list, header, message_on_empty):
 # slackware-current's latest version of python-packaging (24.0 for Python 3.11) will throw
 # an exception on such strings.
 def str_to_version_list(s):
-    return re.split("\.|-|\+", s)
+    return re.split(r'\.|-|\+', s)
 
 # Compare two lists representing the components of a version string. Uses numerical comparison if
 # two elements in the same position are both decimal digit strings (e.g. so "11" will test as

--- a/slackroll
+++ b/slackroll
@@ -1250,6 +1250,27 @@ def key_transient_pkgs(persistent_list):
 def key_pkg_activity_pending(persistent_list): # True if any new, outdated or unavailable package is prioritized
     return (len(key_transient_pkgs(persistent_list)) > 0)
 
+# Filter out candidates with build suffix (e.g. _alien) that does not match any locally-installed version
+def match_local_build_suffix(candidates, local_versions, verbose = False):
+    if local_versions == []: # Nothing to filter against!
+        return candidates
+    name = local_versions[0].name
+
+    local_tags = []
+    for x in local_versions:
+        if x.build_tag not in local_tags:
+            if verbose and len(local_tags) == 1:
+                print("WARNING: package '%s' installed locally under multiple build suffixes and you specified --auto-select" % name)
+            local_tags.append(x.build_tag)
+
+    auto_selected_pkgs = [pkg for pkg in candidates if pkg.build_tag in local_tags]
+    if verbose and auto_selected_pkgs == [] and candidates != []:
+        print("WARNING: no candidate for package '%s' matches any local build tag [%s]" % (name, ', '.join(local_tags)))
+    elif verbose and len(auto_selected_pkgs) == 1 and len(candidates) > 1:
+        # Ensure user realizes some candidates were automatically filtered out, since there won't be a manual selection menu
+        print("    Auto-selected %s" % auto_selected_pkgs[0].fullname)
+    return auto_selected_pkgs
+
 def maybe_print_key_pkg_watchout(persistent_list):
     if key_pkg_activity_pending(persistent_list):
         print('\nWATCH OUT: ACTIVITY IN KEY SYSTEM PACKAGES')
@@ -1769,24 +1790,8 @@ def parse_install_args(args, local_list, remote_list, use_local_version, use_pas
         if not use_pasture: # Filter /pasture/ candidates if indicated
             candidates = not_pasture(candidates)
 
-        # Filter out candidates with a different build suffix (e.g. _alien) than the installed version
         if slackroll_auto_select and name in local_list:
-            local_versions = local_list[name]
-            match_tag = local_versions[0].build_tag
-            print("Auto-selecting against tag '%s'" % match_tag)
-            for x in local_versions[1:]: # Make sure the identified match_tag is the only one used by locally-installed copies
-                if x.build_tag != match_tag:
-                    print("WARNING: package '%s' installed locally under multiple build suffixes and you specified --auto-select" % name)
-                    print("    Matching against '%s', ignoring '%s'" % (match_tag, x.build_tag))
-
-            auto_selected_pkgs = [pkg for pkg in candidates if pkg.build_tag == match_tag]
-            if len(auto_selected_pkgs) == 0 and len(candidates) != 0:
-                print("WARNING: no matches for build tag '%s' on package %s, forcing manual selection" % (match_tag, name))
-            else:
-                if len(auto_selected_pkgs) == 1 and len(candidates) > 1:
-                    # Ensure user realizes some candidates were automatically filtered out, since there won't be a manual selection menu
-                    print('Auto-selected %s' % auto_selected_pkgs[0].fullname)
-                candidates = auto_selected_pkgs
+            candidates = match_local_build_suffix(candidates, local_list[name], True)
 
         # Choose among the candidates
         if len(candidates) == 0:
@@ -2030,10 +2035,10 @@ def verify_num_args(num, opname, arg_list): # Verify number of arguments of a gi
 
     # Before validating the number of "mandatory" arguments, handle any special option parameters:
     global slackroll_auto_select
-    if opname in ["upgrade", "upgrade-key-packages"]:
-        if "--auto-select" in arg_list:
+    if opname in ['upgrade', 'upgrade-key-packages', 'list-upgrades', 'list-upgradable', 'list-upgradeable']:
+        if '--auto-select' in arg_list:
             slackroll_auto_select = True
-            arg_list.remove("--auto-select")
+            arg_list.remove('--auto-select')
 
     if num == -2:
         if len(arg_list) > 1:
@@ -2641,6 +2646,8 @@ if __name__ == "__main__":
                 if len(candidates) == 0:
                     print('    %s: WARNING: only present in /pasture/\n' % name)
                     continue
+                if slackroll_auto_select:
+                    candidates = match_local_build_suffix(candidates, local_list[name])
                 print('    %s:' % name)
                 print('\n'.join('\tLocal:\t%s' % pkg.archivename for pkg in local_list[name]))
                 print('\n'.join('\tRemote:\t%s' % pkg.fullname for pkg in candidates))

--- a/slackroll
+++ b/slackroll
@@ -1360,10 +1360,21 @@ def print_pairs_or(the_list, header, message_on_empty):
 def str_to_version_list(s):
     return re.split(r'\.|-|\+', s)
 
-# Compare two lists representing the components of a version string. Uses numerical comparison if
-# two elements in the same position are both decimal digit strings (e.g. so "11" will test as
+# True iff the provided string consists only of decimal digits
+def all_digits(s):
+    m = re.match(r'(\d+)$', s)
+    if m == None:
+        return False
+    return m.end() == len(s)
+
+# Compare two lists representing the components of a version string.
+#
+# Uses numerical comparison if they're both decimal digit strings (e.g. so "11" will test as
 # less than "101", otherwise tests in lexicographical order (so "b101" tests as less than "b11").
+#
+# Return value will be 1 if v1 is "greater than" v2, 0 if they're equal, -1 if v2 is greater.
 def version_list_cmp(v1, v2):
+    # If the lists are unequal length, treat the longer argument as the "larger" version number
     if not v1 and not v2:
         return 0
     elif v1 and not v2:
@@ -1371,7 +1382,7 @@ def version_list_cmp(v1, v2):
     elif v2 and not v1:
         return -1
 
-    if v1[0].isdigit() and v2[0].isdigit():
+    if all_digits(v1[0]) and all_digits(v2[0]):
         key1, key2 = int(v1[0]), int(v2[0])
     else:
         key1, key2 = v1[0], v2[0]
@@ -1382,16 +1393,29 @@ def version_list_cmp(v1, v2):
     else:
         return 1
 
-def versions_equal(str1, str2):
-    return version_list_cmp(str_to_version_list(str1), str_to_version_list(str2)) == 0
+# True iff the packages share an architecture and build suffix (e.g. _SBo, _alien, etc.)
+# This is used to avoid false-positives when a package with the same main version number as the locally-installed package is
+# available in remote repositories under more than one architecture or build family.
+def comparable_arch_and_build_tag(arch1, build1, arch2, build2):
+    if arch1 != arch2:
+        return False
+    m1 = re.match(r'(\d+)', build1)
+    m2 = re.match(r'(\d+)', build2)
+    return m1 == None and m2 == None or m1 != None and m2 != None and build1[m1.end():] == build2[m2.end():]
 
-def first_is_newer(str1, str2):
-    return version_list_cmp(str_to_version_list(str1), str_to_version_list(str2)) > 0
+# True iff (version2, arch2, build2) appears to be a newer replacement for (version1, arch1, build1)
+# This will ALWAYS be true if version2 is higher than version1, regardless of architecture & build type.
+#
+# Otherwise, if they have identical leading version numbers, the second package is considered a replacement only if
+# its architecture and build tag suffix, if any, are identical to the first package, and the build sequence number is higher.
+def package_superseded_by(version1, arch1, build1, version2, arch2, build2):
+    v_cmp = version_list_cmp(str_to_version_list(version1), str_to_version_list(version2))
+    return v_cmp < 0 or v_cmp == 0 and comparable_arch_and_build_tag(arch1, build1, arch2, build2) and build1 < build2
 
 # True iff the given package has a newer version available in the provided list
 def superseded_in(pkg, the_list):
     name = pkg.name
-    newer_pkgs = [x for x in the_list if x.name == name and (first_is_newer(x.version, pkg.version) or versions_equal(x.version, pkg.version) and x.build > pkg.build)]
+    newer_pkgs = [x for x in the_list if x.name == name and package_superseded_by(pkg.version, pkg.arch, pkg.build, x.version, x.arch, x.build)]
     return len(newer_pkgs) > 0
 
 def tr_pkg_detail(local_list, remote_list, persistent_list, pkg_name): # Returns a string with package details for a transient package

--- a/slackroll
+++ b/slackroll
@@ -1885,7 +1885,10 @@ def is_dotnew_file(path):
     return os.path.isfile(path) and not os.path.islink(path) and path.endswith(slackroll_new_suffix)
 
 def up_to_date(local_versions, remote_versions): # Is the local package up to date?
-    return (len([x for x in local_versions if x in remote_versions]) > 0)
+    for i in local_versions:
+        if not superseded_in(i, remote_versions):
+            return True
+    return False
 
 def outdated_or_installed(local_versions, remote_versions): # Returns outdated or installed state depending on up_to_date()
     return [slackroll_state_outdated, slackroll_state_installed][up_to_date(local_versions, remote_versions)]

--- a/slackroll
+++ b/slackroll
@@ -85,6 +85,7 @@ import pickle
 import fcntl
 import functools
 import glob
+import hashlib
 import math
 import operator
 import os
@@ -154,10 +155,12 @@ slackroll_known_files = os.path.join(slackroll_base_dir, 'knownfiles.db')
 slackroll_blacklist_filename = os.path.join(slackroll_base_dir, 'blacklist.db')
 slackroll_repolist_filename = os.path.join(slackroll_base_dir, 'repos.db')
 slackroll_filelist_filename = 'FILELIST.TXT'
-slackroll_changelog_filename = 'ChangeLog.txt'
+slackroll_changelog_basename = 'ChangeLog'
+slackroll_changelog_suffix = '.txt'
+slackroll_changelog_db_basename = 'changelog'
+slackroll_changelog_db_suffix = '.db'
 slackroll_changelog_entry_separator = '+--------------------------+\n'
 slackroll_local_filelist = os.path.join(slackroll_base_dir, slackroll_filelist_filename)
-slackroll_local_changelog = os.path.join(slackroll_base_dir, 'changelog.db')
 slackroll_gpgkey_filename = 'GPG-KEY'
 slackroll_local_gpgkey = os.path.join(slackroll_base_dir, slackroll_gpgkey_filename)
 slackroll_temp_suffix = '.part'
@@ -201,6 +204,12 @@ slackroll_manifest_filename = os.path.join(slackroll_base_dir, 'manifest.db')
 slackroll_manifest_list_filename = os.path.join(slackroll_base_dir, 'manifestlist.db')
 slackroll_batch_mode = False
 slackroll_auto_select = False
+
+# Cache of all third-party repositories
+slackroll_internal_repo_list = {}
+
+# Track opened DBs so we can clean up manually instead of waiting for program exit
+slackroll_open_databases = {}
 
 def debug_mesg(mesg):
     if debug_output:
@@ -646,21 +655,46 @@ def newer_than(path1, path2): # path1 modification time more recent than path2 m
 def is_readable_file(filepath):
     return os.path.isfile(filepath) and os.access(filepath, os.R_OK)
 
-def try_dump(object, filepath): # pickle.dump()
+def try_dump(object, filepath, caller_handles_exceptions = False): # pickle.dump()
     try:
         pickle.dump(object, open(filepath, 'wb'), pickle_protocol)
     except (OSError, IOError, pickle.PickleError) as err:
-        sys.exit('ERROR: %s' % err)
+        if caller_handles_exceptions:
+            raise err
+        else:
+            sys.exit('ERROR: %s' % err)
 
-def try_load(filepath): # pickle.load()
+def try_load(filepath, caller_handles_exceptions = False): # pickle.load()
+    global slackroll_open_databases
     try:
+        if filepath in slackroll_open_databases:
+            fd = slackroll_open_databases[filepath]
+        else:
+            fd = open(filepath, 'rb')
+            slackroll_open_databases[filepath] = fd
         if PY2:
-            return pickle.load(open(filepath, 'rb'))
+            return pickle.load(fd)
         else:
             # BCS: in case DB was written by a Python 2 instance and contains non-ASCII characters
-            return pickle.load(open(filepath, 'rb'), encoding='Latin1')
+            return pickle.load(fd, encoding='Latin1')
     except (OSError, IOError, pickle.PickleError) as err:
-        sys.exit('ERROR: %s' % err)
+        if caller_handles_exceptions:
+            raise err
+        else:
+            sys.exit('ERROR: %s' % err)
+
+def close_db(filepath, caller_handles_exceptions = False):
+    global slackroll_open_databases
+    try:
+        if filepath in slackroll_open_databases:
+            slackroll_open_databases.pop(filepath).close()
+        else:
+            print('WARNING: tried to close database %s, but it is not open' % filepath)
+    except (OSError, IOError, pickle.PickleError) as err:
+        if caller_handles_exceptions:
+            raise err
+        else:
+            sys.exit('ERROR: %s' % err)
 
 def get_blacklist(): # Get blacklist expression list
     if is_readable_file(slackroll_blacklist_filename):
@@ -880,13 +914,19 @@ def get_mirror_version_components(mirror): # Extract Slackware version component
     return (match.group(1), match.group(2))
 
 def get_repo_list():
+    # BCS: due to database access, this function was not originally idempotent => memoized
+    global slackroll_internal_repo_list
+    if len(slackroll_internal_repo_list) > 0:
+        return slackroll_internal_repo_list
     if not is_readable_file(slackroll_repolist_filename):
-        repo_list = []
-        try_dump(repo_list, slackroll_repolist_filename)
-    return try_load(slackroll_repolist_filename)
+        try_dump([], slackroll_repolist_filename)
+    slackroll_internal_repo_list = try_load(slackroll_repolist_filename)
+    return slackroll_internal_repo_list
 
-def dump_repo_list(repo_list):
-    try_dump(repo_list, slackroll_repolist_filename)
+def dump_repo_list(new_repo_list):
+    global slackroll_internal_repo_list
+    try_dump(new_repo_list, slackroll_repolist_filename)
+    slackroll_internal_repo_list = new_repo_list
 
 def get_pkg_cache_size(): # Return total bytes for files in cache
     try:
@@ -1153,47 +1193,81 @@ def get_remote_info(mirror, package, redownload=False, keep_cached=True): # Down
         try_to_remove(local_file)
     return data
 
-def update_changelog(mirror, full=False): # Returns answer to "has it been updated?"
-    if not os.path.exists(slackroll_local_changelog) or full:
-        temp_dir = get_temp_dir()
-        download_or_exit(mirror, slackroll_changelog_filename, temp_dir)
-        local_filename = os.path.join(temp_dir, slackroll_changelog_filename)
-        text = read_file(local_filename)
-        cl = ChangeLog()
-        cl.add_entries(clentrylist_from_text(text))
-        try_dump(cl, slackroll_local_changelog)
-        try_to_remove(local_filename)
-        return True
+# Return a short hexadecimal hash of the given URL.  Ignore trailing slashes as immaterial.
+# This is only used for a small set of third-party repositories, so collision probability is not a concern.
+def hash_url(url):
+    while url[-1] == '/':
+        url = url[:-1]
+    return hashlib.sha1(url.encode('UTF-8')).hexdigest()[-8:]
 
-    print_flush('Updating change log ... ')
+# Return a list of (URL, hash value) pairs for every configured repository (used for ChangeLog management)
+# The first entry will be the main Slackware mirror, with the empty string as its hash value.
+def enumerate_repos_and_hashes():
+    return [(get_mirror(), '')] + [(repo, hash_url(repo)) for (index, repo) in enumerate(get_repo_list())]
 
-    try: # Only read until last known entry
-        cl = try_load(slackroll_local_changelog)
-        limits = set(concat([[x.timestamp for x in cl.get_batch(y)] for y in range(cl.num_batches())]))
-    except (OSError, IOError) as err:
-        sys.exit('ERROR: %s' % err)
+# Return the local database file corresponding to a given repo's ChangeLog.
+# The key value will be blank for the main Slackware mirror, and a URL hash for third-party repos.
+def local_changelog_db(key):
+    trailing_part = slackroll_changelog_db_basename + ('' if key == '' else '-' + key) + slackroll_changelog_db_suffix
+    return os.path.join(slackroll_base_dir, trailing_part)
 
-    changelog_url = urllib.parse.urljoin(str(mirror), str(slackroll_changelog_filename))
-    lines = []
-    try:
-        conn = urllib.request.urlopen(changelog_url)
-        while True:
-            new_line = interpret_as_str(conn.readline())
-            if len(new_line) == 0 or new_line.strip() in limits:
-                break
-            lines.append(new_line)
-        conn.close()
-    except (OSError, IOError, socket.error, urllib.error.ContentTooShortError) as err:
-        sys.exit('\nERROR: %s' % err)
+# Return the temporary file to use for retrieving a given repo's ChangeLog.
+# Filenames don't really need to be unique since they're usually immediately deleted, but might as well
+# prevent any left-behind remnants (in the event of a previous crash) from causing potential confusion.
+def local_changelog_copy(temp_dir, key):
+    trailing_part = slackroll_changelog_basename + ('' if key == '' else '-' + key) + slackroll_changelog_suffix
+    return os.path.join(temp_dir, trailing_part)
 
-    if len(lines) == 0:
-        print('no new entries.')
-        return False
-    print('new entries found.')
-    cl.start_new_batch()
-    cl.add_entries(clentrylist_from_text(''.join(lines)))
-    try_dump(cl, slackroll_local_changelog)
-    return True
+def update_all_changelogs(full=False): # Returns answer to "have any of the ChangeLogs been updated?"
+    temp_dir = get_temp_dir()
+    found_changes = False
+
+    for (repo_url, key) in enumerate_repos_and_hashes():
+        database = local_changelog_db(key)
+        if not os.path.exists(database) or full:
+            try:
+                download(repo_url, slackroll_changelog_basename + slackroll_changelog_suffix, temp_dir)
+            except SlackrollError:
+                print('Failed to retrieve ChangeLog from %s, continuing' % repo_url)
+                continue
+            local_filename = local_changelog_copy(temp_dir, key)
+            text = read_file(local_filename)
+            cl = ChangeLog()
+            cl.add_entries(clentrylist_from_text(text))
+            try_dump(cl, database)
+            try_to_remove(local_filename)
+            found_changes = True
+
+        print_flush('Updating change log for %s... ' % repo_url)
+        try: # Only read until last known entry
+            cl = try_load(database)
+            limits = set(concat([[x.timestamp for x in cl.get_batch(y)] for y in range(cl.num_batches())]))
+        except (OSError, IOError) as err:
+            sys.exit('ERROR: %s' % err)
+
+        changelog_url = urllib.parse.urljoin(str(repo_url), str(slackroll_changelog_basename + slackroll_changelog_suffix))
+        lines = []
+        try:
+            conn = urllib.request.urlopen(changelog_url)
+            while True:
+                new_line = interpret_as_str(conn.readline())
+                if len(new_line) == 0 or new_line.strip() in limits:
+                    break
+                lines.append(new_line)
+            conn.close()
+        except (OSError, IOError, socket.error, urllib.error.ContentTooShortError) as err:
+            sys.exit('\nERROR: %s' % err)
+
+        if len(lines) == 0:
+            print('no new entries.')
+        else:
+            print('new entries found.')
+            cl.start_new_batch()
+            cl.add_entries(clentrylist_from_text(''.join(lines)))
+            try_dump(cl, database)
+            found_changes = True
+
+    return found_changes
 
 def print_urls(mirror, package):
     sigmirror = get_primary_mirror()
@@ -2356,41 +2430,67 @@ if __name__ == "__main__":
 
         if operation == 'changelog':
             interceptor = SlackrollOutputInterceptor()
-            cl = try_load(slackroll_local_changelog)
-            print(slackroll_changelog_entry_separator.join('%s' % entry for entry in cl.last_batch()))
+            repo_list = enumerate_repos_and_hashes()
+            for (repo_url, key) in repo_list:
+                database = local_changelog_db(key)
+                try:
+                    cl = try_load(database, True)
+                except (OSError, IOError, pickle.PickleError) as err:
+                    continue
+                print(slackroll_changelog_entry_separator.join('%s' % entry for entry in cl.last_batch()))
+                close_db(database)
             interceptor.stop()
             sys.exit()
 
         if operation == 'list-changelog':
             interceptor = SlackrollOutputInterceptor()
-            cl = try_load(slackroll_local_changelog)
-            print('ChangeLog.txt entries:')
-            for idb in range(cl.num_batches() - 1, -1, -1):
-                batch = cl.get_batch(idb)
-                for ide in range(len(batch)):
-                    print('    %-8s  %s' % ('%s.%s' % (idb, ide), batch[ide].timestamp))
+            for (repo_url, key) in enumerate_repos_and_hashes():
+                database = local_changelog_db(key)
+                try:
+                    cl = try_load(database, True)
+                except (OSError, IOError, pickle.PickleError) as err:
+                    continue
+                print('ChangeLog.txt entries from %s:' % repo_url)
+                for idb in range(cl.num_batches() - 1, -1, -1):
+                    batch = cl.get_batch(idb)
+                    for ide in range(len(batch)):
+                        print('    %-8s  %s' % ('%s.%s' % (idb, ide), batch[ide].timestamp))
+                close_db(database)
             print('End of list')
             interceptor.stop()
             sys.exit()
 
         if operation == 'changelog-entries':
-            cl = try_load(slackroll_local_changelog)
             entries = []
-            for code in args:
+            for (repo_url, key) in enumerate_repos_and_hashes():
+                database = local_changelog_db(key)
                 try:
-                    (idb, ide) = code.split('.')
-                    (idb, ide) = (int(idb), int(ide))
-                    entries.append(cl.get_batch(idb)[ide])
-                except (IndexError, ValueError):
-                    sys.exit('ERROR: invalid entry: %s' % code)
+                    cl = try_load(database, True)
+                except (OSError, IOError, pickle.PickleError) as err:
+                    continue
+                for code in args:
+                    try:
+                        (idb, ide) = code.split('.')
+                        (idb, ide) = (int(idb), int(ide))
+                        entries.append(cl.get_batch(idb)[ide])
+                    except (IndexError, ValueError):
+                        sys.exit('ERROR: invalid entry: %s' % code)
+                close_db(database)
             interceptor = SlackrollOutputInterceptor()
             print(slackroll_changelog_entry_separator.join('%s' % x for x in entries))
             interceptor.stop()
             sys.exit()
 
         if operation == 'full-changelog':
-            cl = try_load(slackroll_local_changelog)
-            entries = concat([[x for x in cl.get_batch(y)] for y in range(cl.num_batches() - 1, -1, -1)])
+            entries = []
+            for (repo_url, key) in enumerate_repos_and_hashes():
+                database = local_changelog_db(key)
+                try:
+                    cl = try_load(database, True)
+                except (OSError, IOError, pickle.PickleError) as err:
+                    continue
+                entries += concat([[x for x in cl.get_batch(y)] for y in range(cl.num_batches() - 1, -1, -1)])
+                close_db(database)
             interceptor = SlackrollOutputInterceptor()
             print(slackroll_changelog_entry_separator.join('%s' % x for x in entries))
             interceptor.stop()
@@ -2491,7 +2591,7 @@ if __name__ == "__main__":
             sys.exit()
 
         if operation == 'download-changelog':
-            update_changelog(get_mirror(), full=True)
+            update_all_changelogs(full=True)
             sys.exit()
 
         if operation == 'update-manifest':
@@ -2529,9 +2629,8 @@ if __name__ == "__main__":
         write_self_file_version()
 
         if operation == 'update':
-            mirror = get_mirror()
             print('Package cache size: %s' % optimum_size_conversion(get_pkg_cache_size()))
-            updated = update_changelog(mirror)
+            updated = update_all_changelogs()
             transient_packages_present = any(persistent_list[x] in slackroll_transient_states for x in persistent_list)
             if updated or transient_packages_present:
                 print()

--- a/slackroll
+++ b/slackroll
@@ -200,6 +200,7 @@ slackroll_manifest_basename = 'MANIFEST.bz2'
 slackroll_manifest_filename = os.path.join(slackroll_base_dir, 'manifest.db')
 slackroll_manifest_list_filename = os.path.join(slackroll_base_dir, 'manifestlist.db')
 slackroll_batch_mode = False
+slackroll_auto_select = False
 
 def debug_mesg(mesg):
     if debug_output:
@@ -336,6 +337,10 @@ class SlackwarePackage(object):
     @property
     def fullsigname(self):
         return '%s%s' % (self.fullname, slackroll_signature_suffix)
+
+    @property
+    def build_tag(self):
+        return self.build[re.match(r'(\d+)', self.build).end():]
 
     def __cmp__(self, other):
         return pkg_name_cmp(self.__name, other.__name)
@@ -1764,6 +1769,25 @@ def parse_install_args(args, local_list, remote_list, use_local_version, use_pas
         if not use_pasture: # Filter /pasture/ candidates if indicated
             candidates = not_pasture(candidates)
 
+        # Filter out candidates with a different build suffix (e.g. _alien) than the installed version
+        if slackroll_auto_select and name in local_list:
+            local_versions = local_list[name]
+            match_tag = local_versions[0].build_tag
+            print("Auto-selecting against tag '%s'" % match_tag)
+            for x in local_versions[1:]: # Make sure the identified match_tag is the only one used by locally-installed copies
+                if x.build_tag != match_tag:
+                    print("WARNING: package '%s' installed locally under multiple build suffixes and you specified --auto-select" % name)
+                    print("    Matching against '%s', ignoring '%s'" % (match_tag, x.build_tag))
+
+            auto_selected_pkgs = [pkg for pkg in candidates if pkg.build_tag == match_tag]
+            if len(auto_selected_pkgs) == 0 and len(candidates) != 0:
+                print("WARNING: no matches for build tag '%s' on package %s, forcing manual selection" % (match_tag, name))
+            else:
+                if len(auto_selected_pkgs) == 1 and len(candidates) > 1:
+                    # Ensure user realizes some candidates were automatically filtered out, since there won't be a manual selection menu
+                    print('Auto-selected %s' % auto_selected_pkgs[0].fullname)
+                candidates = auto_selected_pkgs
+
         # Choose among the candidates
         if len(candidates) == 0:
             print('WARNING: %s only present in /pasture/' % name)
@@ -2003,6 +2027,14 @@ def verify_operation_and_args(op_num_args, operation, args): # Verify number of 
 def verify_num_args(num, opname, arg_list): # Verify number of arguments of a given operation
     # -1 means any nonzero quantity
     # -2 means zero or one
+
+    # Before validating the number of "mandatory" arguments, handle any special option parameters:
+    global slackroll_auto_select
+    if opname in ["upgrade", "upgrade-key-packages"]:
+        if "--auto-select" in arg_list:
+            slackroll_auto_select = True
+            arg_list.remove("--auto-select")
+
     if num == -2:
         if len(arg_list) > 1:
             sys.exit('ERROR: %s expects one argument or no arguments' % opname)

--- a/tests/test_prioritised_pkgs.py
+++ b/tests/test_prioritised_pkgs.py
@@ -2,58 +2,52 @@ import os
 
 import toml
 
-from slackroll import transient_cmp
+from slackroll import transient_key
 
 
 def test_transient_cmp_normal_pkg_same_state():
     left = ("python2", "slackroll_state_outdated")
     right = ("python3", "slackroll_state_outdated")
 
-    assert transient_cmp(left, right) == -1
-    assert transient_cmp(right, left) == 1
-    assert transient_cmp(left, left) == 0
+    assert transient_key(left) < transient_key(right)
+    assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_normal_pkg_different_state():
     left = ("python2", "slackroll_state_new")
     right = ("python3", "slackroll_state_outdated")
 
-    assert transient_cmp(left, right) == 0
-    assert transient_cmp(right, left) == 0
-    assert transient_cmp(left, left) == 0
+    assert transient_key(left) == transient_key(right)
+    assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_aaa_glib_solibs():
     left = ("aaa_glibc-solibs", "slackroll_state_new")
     right = ("python3", "slackroll_state_outdated")
 
-    assert transient_cmp(left, right) == -1
-    assert transient_cmp(right, left) == 1
-    assert transient_cmp(left, left) == 0
+    assert transient_key(left) < transient_key(right)
+    assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_glibc_solibs():
     left = ("glibc-solibs", "slackroll_state_new")
     right = ("python3", "slackroll_state_outdated")
 
-    assert transient_cmp(left, right) == -1
-    assert transient_cmp(right, left) == 1
-    assert transient_cmp(left, left) == 0
+    assert transient_key(left) < transient_key(right)
+    assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_sed():
     left = ("sed", "slackroll_state_new")
     right = ("python3", "slackroll_state_outdated")
 
-    assert transient_cmp(left, right) == -1
-    assert transient_cmp(right, left) == 1
-    assert transient_cmp(left, left) == 0
+    assert transient_key(left) < transient_key(right)
+    assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_pkgtools():
     left = ("pkgtools", "slackroll_state_new")
     right = ("python3", "slackroll_state_outdated")
 
-    assert transient_cmp(left, right) == -1
-    assert transient_cmp(right, left) == 1
-    assert transient_cmp(left, left) == 0
+    assert transient_key(left) < transient_key(right)
+    assert transient_key(left) == transient_key(left)

--- a/tests/test_prioritised_pkgs.py
+++ b/tests/test_prioritised_pkgs.py
@@ -2,52 +2,53 @@ import os
 
 import toml
 
-from slackroll import transient_key
+from slackroll import transient_key, slackroll_state_new, slackroll_state_outdated
 
 
 def test_transient_cmp_normal_pkg_same_state():
-    left = ("python2", "slackroll_state_outdated")
-    right = ("python3", "slackroll_state_outdated")
+    left = ("python2", slackroll_state_outdated)
+    right = ("python3", slackroll_state_outdated)
 
     assert transient_key(left) < transient_key(right)
     assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_normal_pkg_different_state():
-    left = ("python2", "slackroll_state_new")
-    right = ("python3", "slackroll_state_outdated")
+    left = ("python3", slackroll_state_new)
+    right = ("python2", slackroll_state_outdated)
 
-    assert transient_key(left) == transient_key(right)
+    # BCS: changed test to verify state sorting takes precedence over package name
+    assert transient_key(left) < transient_key(right)
     assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_aaa_glib_solibs():
-    left = ("aaa_glibc-solibs", "slackroll_state_new")
-    right = ("python3", "slackroll_state_outdated")
+    left = ("aaa_glibc-solibs", slackroll_state_new)
+    right = ("python3", slackroll_state_outdated)
 
     assert transient_key(left) < transient_key(right)
     assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_glibc_solibs():
-    left = ("glibc-solibs", "slackroll_state_new")
-    right = ("python3", "slackroll_state_outdated")
+    left = ("glibc-solibs", slackroll_state_new)
+    right = ("python3", slackroll_state_outdated)
 
     assert transient_key(left) < transient_key(right)
     assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_sed():
-    left = ("sed", "slackroll_state_new")
-    right = ("python3", "slackroll_state_outdated")
+    left = ("sed", slackroll_state_new)
+    right = ("python3", slackroll_state_outdated)
 
     assert transient_key(left) < transient_key(right)
     assert transient_key(left) == transient_key(left)
 
 
 def test_transient_cmp_prioritised_pkg_pkgtools():
-    left = ("pkgtools", "slackroll_state_new")
-    right = ("python3", "slackroll_state_outdated")
+    left = ("pkgtools", slackroll_state_new)
+    right = ("python3", slackroll_state_outdated)
 
     assert transient_key(left) < transient_key(right)
     assert transient_key(left) == transient_key(left)


### PR DESCRIPTION
  - implemented info-* commands for all package states, not just -new
  - kernel-clean now removes all but the latest installed version
    of kernel packages, rather than any version not matching the repo
    (which risked inadvertently leaving zero versions installed)
  - upgrade no longer touches kernel packages (must use kernel-upgrade)
  - list-kernels shows packages that would be affected by kernel-clean or kernel-upgrade
  - foreign-upgradable and frozen-upgradable show packages now available in newer versions in the repo
  - do not unnecessarily prompt the user when there's no *.new file to compare
  - added aliases for multiple commands to ease transition from apt and similar tools