### PR TITLE
Python 3 porting - Stage2 fixes for python 2 raw_input usage.

### DIFF
--- a/slackroll
+++ b/slackroll
@@ -15,6 +15,7 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 from __future__ import print_function
+from builtins import input
 from builtins import range
 import anydbm
 import bz2
@@ -994,7 +995,7 @@ def choose_option(option_list): # Prompt user and return option index
     codes = [x[0].lower() for x in option_list]
     while True:
         print_flush('You choose option... ')
-        chosen = raw_input().lower()
+        chosen = input().lower()
         if chosen not in codes:
             continue
         break
@@ -1067,7 +1068,7 @@ def print_repo_mod_advice():
 def maybe_confirm_continue():
     if slackroll_batch_mode:
         return
-    raw_input('Press Ctrl+C to cancel or Enter to continue... ')
+    input('Press Ctrl+C to cancel or Enter to continue... ')
 
 def print_in_states(states, persistent_list, header, print_state): # Print package name if its state matches
     keys = pkgs_in_state(persistent_list, states)


### PR DESCRIPTION
Following the guide on https://python-future.org/automatic_conversion.html#stage-2-py3-style-code-with-wrappers-for-py2

I've applied only the raw_input fixes from stage2:

```
futurize --stage2 -w -f lib2to3.fixes.fix_raw_input slackroll
```