### PR TITLE
Fix `next` on generator missed in stage1 fixes.

### DIFF
--- a/slackroll
+++ b/slackroll
@@ -842,7 +842,7 @@ def yield_gnupg_exec_name():
             pass
     sys.exit('ERROR: unable to run GnuPG')
 
-gnupg_exec_name = yield_gnupg_exec_name().next
+gnupg_exec_name = next(yield_gnupg_exec_name())
 
 def import_key(filename):
     try:


### PR DESCRIPTION
The yield_gnupg_exec_name function yields, but it did not get wrapped with next() in 78e7d9f.

If we don't fix this here, the stage2 fixer with "fix" this and break the code.