### PR TITLE
Python 3 porting - Stage2 fixes builtins.

### DIFF
--- a/slackroll
+++ b/slackroll
@@ -15,6 +15,8 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 from __future__ import print_function
+from builtins import next
+from builtins import str
 from past.builtins import cmp
 from builtins import input
 from builtins import range


### PR DESCRIPTION
Following the guide on https://python-future.org/automatic_conversion.html#stage-2-py3-style-code-with-wrappers-for-py2

I've applied only the libfuturize.fixes.fix_future_builtins fixes from stage2:

```
futurize --stage2 -w -f libfuturize.fixes.fix_future_builtins slackroll
```