### PR TITLE
Python 3 porting - Stage2 fixes for object.

### DIFF
--- a/slackroll
+++ b/slackroll
@@ -15,6 +15,7 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 from __future__ import print_function
+from builtins import object
 from future import standard_library
 standard_library.install_aliases()
 from builtins import next


### PR DESCRIPTION
Following the guide on https://python-future.org/automatic_conversion.html#stage-2-py3-style-code-with-wrappers-for-py2

I've applied only the libfuturize.fixes.fix_object fixes from stage2:

```
futurize --stage2 -w -f libfuturize.fixes.fix_object slackroll
```