### PR TITLE
Mop up final stage2 fixes.

### DIFF
--- a/slackroll
+++ b/slackroll
@@ -14,15 +14,19 @@
 # this software. If not, see
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
+
 from __future__ import print_function
-from builtins import object
+from past.builtins import cmp
+
 from future import standard_library
 standard_library.install_aliases()
-from builtins import next
-from builtins import str
-from past.builtins import cmp
+
 from builtins import input
+from builtins import next
+from builtins import object
 from builtins import range
+from builtins import str
+
 import anydbm
 import bz2
 import pickle
@@ -1420,7 +1424,7 @@ def search_manifest_database(regexp):
     manifestdb = try_load(slackroll_manifest_filename)
 
     results = []
-    for k in manifestdb.keys():
+    for k in list(manifestdb.keys()):
         if regexp.search(k) is not None:
             results.append(k)
 


### PR DESCRIPTION
Following the guide on https://python-future.org/automatic_conversion.html#stage-2-py3-style-code-with-wrappers-for-py2

I've now applied all the stage2 fixes.

We'll iterate on tests and python3 now and start pulling in changes from @spillner.

futurize is installed by default on 15.0. We might want to support older slackware versions, but first we will get everything working on 15.0 with python2 and python3 and good test coverage. We can still branch out to testing with current and potentially older releases. (which might mean dropping the futurize dependency again).